### PR TITLE
feat(protocol): align MCP tool schemas with PROTOCOL.md for v0.5.0

### DIFF
--- a/claudecode-nova.novaextension/CHANGELOG.md
+++ b/claudecode-nova.novaextension/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## 0.5.0 — 2026-05-15
+
+### Changed
+- **MCP tool schemas now match the VS Code / Neovim `PROTOCOL.md` spec
+  verbatim.** Audited `tools/list` against
+  [coder/claudecode.nvim/PROTOCOL.md](https://github.com/coder/claudecode.nvim/blob/main/PROTOCOL.md)
+  (v0.3.0) and fixed four divergences so Claude Code CLI sends exactly
+  what our bridge expects.
+
+  | Tool | Before | After (spec) |
+  |---|---|---|
+  | `openFile` | `{filePath, lineNumber, selectText}` | `{filePath, preview, startText, endText, selectToEndOfLine, makeFrontmost}` |
+  | `openDiff` | `{filePath, oldContent, newContent, tabName}` | `{old_file_path, new_file_path, new_file_contents, tab_name}` |
+  | `getDiagnostics` | `{filePath}` | `{uri}` |
+  | `closeAllDiffTabs` return | `{success, rejected}` object | `"CLOSED_${N}_DIFF_TABS"` plain string |
+
+- **`openFile` output shape** now follows the spec: a plain `"Opened
+  file: <path>"` string when `makeFrontmost=true` (default), versus the
+  detailed JSON `{success, filePath, languageId, lineCount}` when
+  `makeFrontmost=false`. `preview` is accepted but ignored (Nova has no
+  preview mode).
+- **`openFile` pattern-based selection** — `startText` / `endText` find
+  positions in the document and select that range, optionally extended
+  to end of line via `selectToEndOfLine`. Replaces the ad-hoc
+  `lineNumber` parameter.
+- **`openDiff` diff stats** are now computed against `old_file_path`
+  (the original file on disk) and applied to `new_file_path` on Accept.
+  Best-effort handling of rename-style diffs where the two paths
+  differ.
+- **`getDiagnostics`** returns the spec-shaped envelope
+  `[{uri, diagnostics: []}]`. Always empty — Nova has no LSP /
+  diagnostics public API — but the shape matches what Claude expects to
+  deserialize.
+- **Tool-result wire format** in `ws-server.js` now respects the
+  handler's return type: plain strings flow through verbatim
+  (`"TAB_CLOSED"`, `"FILE_SAVED"`, `"DIFF_REJECTED"`, …), objects are
+  `JSON.stringify`-wrapped, and error results surface via the MCP
+  `isError` flag.
+
+### Added
+- **`close_tab` tool** (`{tab_name}` → `"TAB_CLOSED"`) — Nova has no
+  public close-tab API, so this is an honest no-op that still honors
+  the protocol contract.
+- **`executeCode` tool** (`{code}` → MCP error) — Jupyter kernel
+  execution. Nova doesn't ship a notebook runtime, so the tool surfaces
+  a clear `isError` response (`"executeCode is not supported in Nova
+  (no Jupyter kernel)"`) rather than silently no-op'ing.
+
+### Notes
+- Breaking change for any non-Claude consumer of the bridge's
+  `tools/list`. The only known consumer is Claude Code CLI itself
+  (which sends the spec names), so this should be net positive in
+  practice.
+- `Scripts/call-bridge.js` examples updated to reflect the new param
+  names.
+- No changes to the lock-file format, auth header
+  (`x-claude-code-ide-authorization`), or notification methods
+  (`selection_changed` / `at_mentioned`) — those were already
+  spec-conforming after v0.4.0.
+
 ## 0.4.1 — 2026-05-15
 
 ### Fixed

--- a/claudecode-nova.novaextension/Scripts/call-bridge.js
+++ b/claudecode-nova.novaextension/Scripts/call-bridge.js
@@ -3,7 +3,7 @@
  * Direct CLI client for the Claude Code ↔ Nova bridge.
  *
  * The Claude Code CLI only forwards `mcp__ide__getDiagnostics` to the model,
- * so the other 9 MCP tools registered by ws-server.js (getOpenEditors,
+ * so the other 11 MCP tools registered by ws-server.js (getOpenEditors,
  * getCurrentSelection, openFile, openDiff, …) are unreachable from a model
  * conversation. This script connects to the bridge directly via the lock
  * file under `~/.claude/ide/<port>.lock` and invokes any tool by name.
@@ -34,7 +34,9 @@ const TOOLS = [
   "checkDocumentDirty",
   "saveDocument",
   "getDiagnostics",
+  "close_tab",
   "closeAllDiffTabs",
+  "executeCode",
 ];
 
 function usage() {
@@ -45,7 +47,9 @@ function usage() {
     "Examples:\n" +
     "  node call-bridge.js getOpenEditors\n" +
     "  node call-bridge.js getCurrentSelection\n" +
-    "  node call-bridge.js openFile '{\"filePath\":\"/abs/path\",\"lineNumber\":42}'\n"
+    "  node call-bridge.js openFile '{\"filePath\":\"/abs/path\",\"makeFrontmost\":false}'\n" +
+    "  node call-bridge.js openDiff '{\"old_file_path\":\"/abs/a\",\"new_file_path\":\"/abs/a\",\"new_file_contents\":\"...\",\"tab_name\":\"proposed\"}'\n" +
+    "  node call-bridge.js getDiagnostics '{\"uri\":\"file:///abs/path\"}'\n"
   );
 }
 

--- a/claudecode-nova.novaextension/Scripts/main.js
+++ b/claudecode-nova.novaextension/Scripts/main.js
@@ -367,8 +367,14 @@ async function handleToolCall(msg) {
       case "getDiagnostics":
         result = toolGetDiagnostics(args);
         break;
+      case "close_tab":
+        result = toolCloseTab(args);
+        break;
       case "closeAllDiffTabs":
         result = toolCloseAllDiffTabs();
+        break;
+      case "executeCode":
+        result = toolExecuteCode(args);
         break;
       default:
         result = { error: "Unknown tool: " + tool };
@@ -394,25 +400,68 @@ async function handleToolCall(msg) {
 }
 
 // --- openFile ---
+//
+// Schema per PROTOCOL.md: {filePath, preview, startText, endText,
+// selectToEndOfLine, makeFrontmost}. Nova does not expose a real preview
+// mode (`preview` is accepted but ignored — file always opens normally) and
+// openFile() always focuses the new editor, so `makeFrontmost: false` is
+// best-effort and only changes the response shape, not the side effects.
 async function toolOpenFile(args) {
   var filePath = args.filePath;
   if (!filePath) return { error: "filePath is required" };
 
-  try {
-    await nova.workspace.openFile(filePath);
+  var makeFrontmost = args.makeFrontmost !== false;  // default true
+  var startText = args.startText;
+  var endText = args.endText;
+  var selectToEndOfLine = !!args.selectToEndOfLine;
 
-    if (args.lineNumber) {
+  try {
+    var editor = await nova.workspace.openFile(filePath);
+
+    // The openFile() Promise sometimes resolves before the editor is fully
+    // ready — re-fetch from active editor as a safety net.
+    if (!editor || !editor.document || editor.document.path !== filePath) {
       await delay(100);
-      var editor = nova.workspace.activeTextEditor;
-      if (editor && editor.document.path === filePath) {
-        var line = Math.max(0, args.lineNumber - 1);
-        var lineRange = editor.document.getLineRangeForRange(new Range(line, line));
-        editor.selectedRange = new Range(lineRange.start, lineRange.start);
+      editor = nova.workspace.activeTextEditor;
+    }
+
+    // Pattern-based selection (startText … endText). Both required to apply.
+    if (editor && editor.document && startText && endText) {
+      var doc = editor.document;
+      var fullText = doc.getTextInRange(new Range(0, doc.length));
+      var startIdx = fullText.indexOf(startText);
+      var endIdx = startIdx >= 0 ? fullText.indexOf(endText, startIdx + startText.length) : -1;
+      if (startIdx >= 0 && endIdx >= 0) {
+        var selEnd = endIdx + endText.length;
+        if (selectToEndOfLine) {
+          var lineRange = doc.getLineRangeForRange(new Range(selEnd, selEnd));
+          selEnd = lineRange.end;
+        }
+        editor.selectedRange = new Range(startIdx, selEnd);
         editor.scrollToCursorPosition();
       }
     }
 
-    return { success: true, filePath: filePath };
+    if (makeFrontmost) {
+      return "Opened file: " + filePath;
+    }
+
+    // makeFrontmost=false response carries doc metadata. lineCount is computed
+    // by counting LF chars (cheap; same approach as offsetToPosition).
+    var lineCount = 0;
+    if (editor && editor.document) {
+      var text = editor.document.getTextInRange(new Range(0, editor.document.length));
+      lineCount = 1;
+      for (var i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === 10) lineCount++;
+      }
+    }
+    return {
+      success: true,
+      filePath: filePath,
+      languageId: (editor && editor.document && editor.document.syntax) || "plaintext",
+      lineCount: lineCount,
+    };
   } catch (err) {
     return { error: err.message };
   }
@@ -420,14 +469,22 @@ async function toolOpenFile(args) {
 
 // --- openDiff ---
 //
+// Schema per PROTOCOL.md: {old_file_path, new_file_path, new_file_contents,
+// tab_name}. Most calls use old_file_path === new_file_path (in-place edit);
+// when they differ, we treat new_file_path as the write target on Accept.
+//
 // Stages the proposed change as a temp file alongside the original, registers
 // it in pendingDiffs so the sidebar can show it, and posts an Accept/Reject
 // notification. Either path (notification button OR sidebar command) ends up
 // calling resolveDiff(diffId, accepted).
 async function toolOpenDiff(args, requestId) {
-  var filePath = args.filePath;
-  var newContent = args.newContent;
-  var tabName = args.tabName;
+  var oldPath = args.old_file_path;
+  var newPath = args.new_file_path || oldPath;
+  var newContent = args.new_file_contents;
+  var tabName = args.tab_name;
+
+  // Internal name: `filePath` is the write target on accept (i.e. new_file_path).
+  var filePath = newPath;
 
   try {
     var tmpDir = nova.path.join(nova.extension.globalStoragePath, "diffs");
@@ -438,13 +495,17 @@ async function toolOpenDiff(args, requestId) {
     file.write(newContent);
     file.close();
 
-    await nova.workspace.openFile(filePath);
+    // Open the original (oldPath) so the user has the "before" tab in view,
+    // then the proposed-changes tmp file. If old/new differ (rename case),
+    // newPath may not exist on disk yet — openFile errors are non-fatal here.
+    try { await nova.workspace.openFile(oldPath); } catch (_) {}
     await nova.workspace.openFile(tmpFile);
 
     // Cheap line-count delta. Not a real LCS diff — just enough so the user
-    // can spot a 200-line rewrite vs. a 3-line tweak at a glance. We read the
-    // original file from disk (best-effort: missing file = new file = all add).
-    var stats = computeDiffStats(filePath, newContent);
+    // can spot a 200-line rewrite vs. a 3-line tweak at a glance. Read the
+    // ORIGINAL file (oldPath) from disk: best-effort, missing file = new file
+    // = all add.
+    var stats = computeDiffStats(oldPath, newContent);
 
     var diffId = "diff_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
     pendingDiffs.unshift({
@@ -628,11 +689,31 @@ async function toolSaveDocument(args) {
 }
 
 // --- getDiagnostics ---
+//
+// Spec returns an array of {uri, diagnostics: [...]} entries. Nova has no
+// LSP/diagnostics public API, so we always return an empty diagnostics list,
+// but with the spec-shaped envelope so Claude's deserialization succeeds.
 function toolGetDiagnostics(args) {
-  return {
-    diagnostics: [],
-    filePath: args.filePath || null,
-  };
+  var uri = args && args.uri ? args.uri : null;
+  return uri ? [{ uri: uri, diagnostics: [] }] : [];
+}
+
+// --- close_tab ---
+//
+// Spec asks for "TAB_CLOSED" on success. Nova has no public close-tab API,
+// so this is a no-op that still reports success — keeps the protocol contract
+// even though the editor tab stays open.
+function toolCloseTab(args) {
+  return "TAB_CLOSED";
+}
+
+// --- executeCode ---
+//
+// Jupyter kernel execution. Nova doesn't ship a notebook runtime, so we
+// surface a clear error rather than silently no-op'ing — Claude will see
+// isError=true and know not to retry.
+function toolExecuteCode(args) {
+  return { error: "executeCode is not supported in Nova (no Jupyter kernel)" };
 }
 
 // --- closeAllDiffTabs ---
@@ -664,7 +745,8 @@ function toolCloseAllDiffTabs() {
     }
   } catch (_) {}
 
-  return { success: true, rejected: rejected };
+  // Spec wire format: plain string "CLOSED_${count}_DIFF_TABS".
+  return "CLOSED_" + rejected + "_DIFF_TABS";
 }
 
 // ---------------------------------------------------------------------------

--- a/claudecode-nova.novaextension/Scripts/ws-server.js
+++ b/claudecode-nova.novaextension/Scripts/ws-server.js
@@ -174,70 +174,91 @@ function registerTool(name, schema, description) {
   tools[name] = { schema, description };
 }
 
-// Register the 10 MCP tools that Claude Code expects (matching VS Code / Neovim)
+// Register the 12 MCP tools that Claude Code expects, matching the VS Code /
+// Neovim PROTOCOL.md schemas verbatim. Param names and casing here are the
+// contract Claude consumes via tools/list — don't deviate.
 registerTool("openFile", {
   type: "object",
   properties: {
-    filePath:  { type: "string", description: "Absolute path of the file to open" },
-    lineNumber: { type: "number", description: "Line number to scroll to" },
-    selectText: { type: "string", description: "Text to select after opening" },
+    filePath:           { type: "string",  description: "Path to the file to open" },
+    preview:            { type: "boolean", description: "Open in preview mode",                 default: false },
+    startText:          { type: "string",  description: "Text pattern marking selection start" },
+    endText:            { type: "string",  description: "Text pattern marking selection end" },
+    selectToEndOfLine:  { type: "boolean", description: "Extend selection to end of line",      default: false },
+    makeFrontmost:      { type: "boolean", description: "Make the file the active editor tab", default: true },
   },
   required: ["filePath"],
-}, "Open a file in the IDE");
+}, "Open a file in the editor and optionally select a range of text");
 
 registerTool("openDiff", {
   type: "object",
   properties: {
-    filePath: { type: "string", description: "Absolute file path" },
-    oldContent: { type: "string", description: "Original file content" },
-    newContent: { type: "string", description: "Proposed new content" },
-    tabName:   { type: "string", description: "Tab label for the diff view" },
+    old_file_path:     { type: "string", description: "Path to original file" },
+    new_file_path:     { type: "string", description: "Path to new file" },
+    new_file_contents: { type: "string", description: "Contents of the new file" },
+    tab_name:          { type: "string", description: "Tab name for the diff view" },
   },
-  required: ["filePath", "oldContent", "newContent"],
-}, "Open a diff view for proposed changes");
+  required: ["old_file_path", "new_file_path", "new_file_contents", "tab_name"],
+}, "Open a git diff for the file (blocking operation)");
 
 registerTool("getCurrentSelection", {
   type: "object", properties: {},
-}, "Get the current editor selection");
+}, "Get the current text selection in the active editor");
 
 registerTool("getLatestSelection", {
   type: "object", properties: {},
-}, "Get the most recent editor selection");
+}, "Get the most recent text selection (even if not in active editor)");
 
 registerTool("getOpenEditors", {
   type: "object", properties: {},
-}, "List all open editor tabs");
+}, "Get information about currently open editors");
 
 registerTool("getWorkspaceFolders", {
   type: "object", properties: {},
-}, "Get workspace folder paths");
+}, "Get all workspace folders currently open in the IDE");
 
 registerTool("checkDocumentDirty", {
   type: "object",
   properties: {
-    filePath: { type: "string", description: "File path to check" },
+    filePath: { type: "string", description: "Path to the file to check" },
   },
   required: ["filePath"],
-}, "Check if a document has unsaved changes");
+}, "Check if a document has unsaved changes (is dirty)");
 
 registerTool("saveDocument", {
   type: "object",
   properties: {
-    filePath: { type: "string", description: "File path to save" },
+    filePath: { type: "string", description: "Path to the file to save" },
   },
   required: ["filePath"],
-}, "Save a document");
+}, "Save a document with unsaved changes");
 
 registerTool("getDiagnostics", {
   type: "object",
   properties: {
-    filePath: { type: "string", description: "File path to get diagnostics for" },
+    uri: { type: "string", description: "File URI to get diagnostics for. If not provided, gets diagnostics for all files." },
   },
-}, "Get LSP diagnostics / issues for a file");
+}, "Get language diagnostics from the editor");
+
+registerTool("close_tab", {
+  type: "object",
+  properties: {
+    tab_name: { type: "string", description: "Name of the tab to close" },
+  },
+  required: ["tab_name"],
+}, "Close a tab by name");
 
 registerTool("closeAllDiffTabs", {
   type: "object", properties: {},
-}, "Clean up temporary diff files staged for review (Nova does not expose a tab-close API; this removes the proposed_* files in extension storage)");
+}, "Close all diff tabs in the editor");
+
+registerTool("executeCode", {
+  type: "object",
+  properties: {
+    code: { type: "string", description: "The code to be executed on the kernel" },
+  },
+  required: ["code"],
+}, "Execute Python code in the Jupyter kernel for the current notebook file");
 
 // ---------------------------------------------------------------------------
 // MCP message handling
@@ -406,13 +427,24 @@ function handleNovaMessage(msg) {
     if (pending) {
       clearTimeout(pending.timeout);
       delete pendingRequests[msg.requestId];
-      
+
+      // Spec output formats vary per tool: some return plain strings
+      // ("TAB_CLOSED", "Opened file: /path"), others return JSON-stringified
+      // objects. Preserve the handler's intent: a string result becomes the
+      // text verbatim, an object/array gets JSON-stringified, and an error
+      // surfaces via isError per MCP convention.
+      const r = msg.result;
+      const isErr = r && typeof r === "object" && r.error;
+      const text = (typeof r === "string")
+        ? r
+        : JSON.stringify(isErr ? { error: r.error } : r);
+      const payload = { content: [{ type: "text", text }] };
+      if (isErr) payload.isError = true;
+
       sendWSMessage(pending.client, {
         jsonrpc: "2.0",
         id: pending.mcpId,
-        result: {
-          content: [{ type: "text", text: JSON.stringify(msg.result) }],
-        },
+        result: payload,
       });
     }
     return;
@@ -462,21 +494,22 @@ function handleNovaMessage(msg) {
       delete pendingRequests[msg.requestId];
 
       const resultText = msg.accepted ? "FILE_SAVED" : "DIFF_REJECTED";
-      const payload = { result: resultText };
-      // Surface user edits made in the proposed-changes tab before Accept.
-      // Lets Claude reconcile its plan with what was actually written to disk
-      // (mirrors the v2.1.110 Write+IDE diff awareness behaviour).
+      // Happy path: plain string per PROTOCOL.md ("FILE_SAVED" / "DIFF_REJECTED").
+      // User-edit path: JSON envelope carrying the post-edit content so Claude
+      // can reconcile its plan with what actually hit disk (mirrors v2.1.110
+      // Write+IDE diff awareness). Strictly additive — only emitted when the
+      // user typed in the proposed-changes tab before Accept.
+      let text = resultText;
       if (msg.userEdited) {
-        payload.userEdited = true;
-        if (msg.finalContent !== undefined) {
-          payload.finalContent = msg.finalContent;
-        }
+        const payload = { result: resultText, userEdited: true };
+        if (msg.finalContent !== undefined) payload.finalContent = msg.finalContent;
+        text = JSON.stringify(payload);
       }
       sendWSMessage(pending.client, {
         jsonrpc: "2.0",
         id: pending.mcpId,
         result: {
-          content: [{ type: "text", text: JSON.stringify(payload) }],
+          content: [{ type: "text", text }],
         },
       });
     }

--- a/claudecode-nova.novaextension/extension.json
+++ b/claudecode-nova.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Claude Code Bridge",
   "organization": "okapi-ca",
   "description": "Integrates Claude Code CLI with Nova via the WebSocket MCP protocol, providing context sharing, diff viewing, and selection tracking.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "categories": ["commands", "sidebars"],
   "license": "MIT",
   "repository": "https://github.com/okapi-ca/claudecode-nova",

--- a/claudecode-nova.novaextension/main.js
+++ b/claudecode-nova.novaextension/main.js
@@ -367,8 +367,14 @@ async function handleToolCall(msg) {
       case "getDiagnostics":
         result = toolGetDiagnostics(args);
         break;
+      case "close_tab":
+        result = toolCloseTab(args);
+        break;
       case "closeAllDiffTabs":
         result = toolCloseAllDiffTabs();
+        break;
+      case "executeCode":
+        result = toolExecuteCode(args);
         break;
       default:
         result = { error: "Unknown tool: " + tool };
@@ -394,25 +400,68 @@ async function handleToolCall(msg) {
 }
 
 // --- openFile ---
+//
+// Schema per PROTOCOL.md: {filePath, preview, startText, endText,
+// selectToEndOfLine, makeFrontmost}. Nova does not expose a real preview
+// mode (`preview` is accepted but ignored — file always opens normally) and
+// openFile() always focuses the new editor, so `makeFrontmost: false` is
+// best-effort and only changes the response shape, not the side effects.
 async function toolOpenFile(args) {
   var filePath = args.filePath;
   if (!filePath) return { error: "filePath is required" };
 
-  try {
-    await nova.workspace.openFile(filePath);
+  var makeFrontmost = args.makeFrontmost !== false;  // default true
+  var startText = args.startText;
+  var endText = args.endText;
+  var selectToEndOfLine = !!args.selectToEndOfLine;
 
-    if (args.lineNumber) {
+  try {
+    var editor = await nova.workspace.openFile(filePath);
+
+    // The openFile() Promise sometimes resolves before the editor is fully
+    // ready — re-fetch from active editor as a safety net.
+    if (!editor || !editor.document || editor.document.path !== filePath) {
       await delay(100);
-      var editor = nova.workspace.activeTextEditor;
-      if (editor && editor.document.path === filePath) {
-        var line = Math.max(0, args.lineNumber - 1);
-        var lineRange = editor.document.getLineRangeForRange(new Range(line, line));
-        editor.selectedRange = new Range(lineRange.start, lineRange.start);
+      editor = nova.workspace.activeTextEditor;
+    }
+
+    // Pattern-based selection (startText … endText). Both required to apply.
+    if (editor && editor.document && startText && endText) {
+      var doc = editor.document;
+      var fullText = doc.getTextInRange(new Range(0, doc.length));
+      var startIdx = fullText.indexOf(startText);
+      var endIdx = startIdx >= 0 ? fullText.indexOf(endText, startIdx + startText.length) : -1;
+      if (startIdx >= 0 && endIdx >= 0) {
+        var selEnd = endIdx + endText.length;
+        if (selectToEndOfLine) {
+          var lineRange = doc.getLineRangeForRange(new Range(selEnd, selEnd));
+          selEnd = lineRange.end;
+        }
+        editor.selectedRange = new Range(startIdx, selEnd);
         editor.scrollToCursorPosition();
       }
     }
 
-    return { success: true, filePath: filePath };
+    if (makeFrontmost) {
+      return "Opened file: " + filePath;
+    }
+
+    // makeFrontmost=false response carries doc metadata. lineCount is computed
+    // by counting LF chars (cheap; same approach as offsetToPosition).
+    var lineCount = 0;
+    if (editor && editor.document) {
+      var text = editor.document.getTextInRange(new Range(0, editor.document.length));
+      lineCount = 1;
+      for (var i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === 10) lineCount++;
+      }
+    }
+    return {
+      success: true,
+      filePath: filePath,
+      languageId: (editor && editor.document && editor.document.syntax) || "plaintext",
+      lineCount: lineCount,
+    };
   } catch (err) {
     return { error: err.message };
   }
@@ -420,14 +469,22 @@ async function toolOpenFile(args) {
 
 // --- openDiff ---
 //
+// Schema per PROTOCOL.md: {old_file_path, new_file_path, new_file_contents,
+// tab_name}. Most calls use old_file_path === new_file_path (in-place edit);
+// when they differ, we treat new_file_path as the write target on Accept.
+//
 // Stages the proposed change as a temp file alongside the original, registers
 // it in pendingDiffs so the sidebar can show it, and posts an Accept/Reject
 // notification. Either path (notification button OR sidebar command) ends up
 // calling resolveDiff(diffId, accepted).
 async function toolOpenDiff(args, requestId) {
-  var filePath = args.filePath;
-  var newContent = args.newContent;
-  var tabName = args.tabName;
+  var oldPath = args.old_file_path;
+  var newPath = args.new_file_path || oldPath;
+  var newContent = args.new_file_contents;
+  var tabName = args.tab_name;
+
+  // Internal name: `filePath` is the write target on accept (i.e. new_file_path).
+  var filePath = newPath;
 
   try {
     var tmpDir = nova.path.join(nova.extension.globalStoragePath, "diffs");
@@ -438,13 +495,17 @@ async function toolOpenDiff(args, requestId) {
     file.write(newContent);
     file.close();
 
-    await nova.workspace.openFile(filePath);
+    // Open the original (oldPath) so the user has the "before" tab in view,
+    // then the proposed-changes tmp file. If old/new differ (rename case),
+    // newPath may not exist on disk yet — openFile errors are non-fatal here.
+    try { await nova.workspace.openFile(oldPath); } catch (_) {}
     await nova.workspace.openFile(tmpFile);
 
     // Cheap line-count delta. Not a real LCS diff — just enough so the user
-    // can spot a 200-line rewrite vs. a 3-line tweak at a glance. We read the
-    // original file from disk (best-effort: missing file = new file = all add).
-    var stats = computeDiffStats(filePath, newContent);
+    // can spot a 200-line rewrite vs. a 3-line tweak at a glance. Read the
+    // ORIGINAL file (oldPath) from disk: best-effort, missing file = new file
+    // = all add.
+    var stats = computeDiffStats(oldPath, newContent);
 
     var diffId = "diff_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
     pendingDiffs.unshift({
@@ -628,11 +689,31 @@ async function toolSaveDocument(args) {
 }
 
 // --- getDiagnostics ---
+//
+// Spec returns an array of {uri, diagnostics: [...]} entries. Nova has no
+// LSP/diagnostics public API, so we always return an empty diagnostics list,
+// but with the spec-shaped envelope so Claude's deserialization succeeds.
 function toolGetDiagnostics(args) {
-  return {
-    diagnostics: [],
-    filePath: args.filePath || null,
-  };
+  var uri = args && args.uri ? args.uri : null;
+  return uri ? [{ uri: uri, diagnostics: [] }] : [];
+}
+
+// --- close_tab ---
+//
+// Spec asks for "TAB_CLOSED" on success. Nova has no public close-tab API,
+// so this is a no-op that still reports success — keeps the protocol contract
+// even though the editor tab stays open.
+function toolCloseTab(args) {
+  return "TAB_CLOSED";
+}
+
+// --- executeCode ---
+//
+// Jupyter kernel execution. Nova doesn't ship a notebook runtime, so we
+// surface a clear error rather than silently no-op'ing — Claude will see
+// isError=true and know not to retry.
+function toolExecuteCode(args) {
+  return { error: "executeCode is not supported in Nova (no Jupyter kernel)" };
 }
 
 // --- closeAllDiffTabs ---
@@ -664,7 +745,8 @@ function toolCloseAllDiffTabs() {
     }
   } catch (_) {}
 
-  return { success: true, rejected: rejected };
+  // Spec wire format: plain string "CLOSED_${count}_DIFF_TABS".
+  return "CLOSED_" + rejected + "_DIFF_TABS";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Aligns the bridge's MCP `tools/list` schemas with the spec at [coder/claudecode.nvim/PROTOCOL.md](https://github.com/coder/claudecode.nvim/blob/main/PROTOCOL.md), based on a conceptual diff between our implementation and the reverse-engineered VS Code extension spec.

Four schema divergences fixed and two missing tools added — Claude Code CLI now gets exactly what `PROTOCOL.md` describes when it calls our bridge.

## Schema fixes

| Tool | Before | After (spec) |
|---|---|---|
| `openFile` | `{filePath, lineNumber, selectText}` | `{filePath, preview, startText, endText, selectToEndOfLine, makeFrontmost}` + spec output shape (plain `"Opened file: <path>"` when `makeFrontmost=true`, JSON `{success, filePath, languageId, lineCount}` otherwise) |
| `openDiff` | `{filePath, oldContent, newContent, tabName}` | `{old_file_path, new_file_path, new_file_contents, tab_name}` — diff stats now read from `old_file_path`; `new_file_path` is the write target on Accept (best-effort handling of rename-style diffs) |
| `getDiagnostics` | `{filePath}` → `{diagnostics, filePath}` | `{uri}` → spec-shaped `[{uri, diagnostics: []}]` (always empty — Nova has no LSP/diagnostics public API) |
| `closeAllDiffTabs` | `{success, rejected}` object | `"CLOSED_${N}_DIFF_TABS"` plain string |

## New tools

- **`close_tab`** `{tab_name}` → `"TAB_CLOSED"`. Nova has no public close-tab API; honest no-op that still honors the protocol contract.
- **`executeCode`** `{code}` → MCP `isError` with message `"executeCode is not supported in Nova (no Jupyter kernel)"`. Surfaces the unsupported state clearly so Claude doesn't retry.

## Wire format

Tool-result envelope in `ws-server.js` now respects the handler's return type:

- string → emitted verbatim as `text` (matches spec "TAB_CLOSED", "Opened file: …", "FILE_SAVED", "DIFF_REJECTED")
- object → `JSON.stringify` (existing behaviour)
- error result → `isError: true` per MCP convention

`diff_response` plain path is now exactly `"FILE_SAVED"` / `"DIFF_REJECTED"` per spec; user-edit path still emits the additive JSON envelope `{result, userEdited, finalContent}` (extension-specific, preserves the v2.1.110 Write+IDE diff awareness behaviour).

## Risks / behavioural changes

- **Breaking for any non-Claude consumer of our `tools/list`** — param names changed for `openFile`, `openDiff`, `getDiagnostics`. The only known consumer is Claude Code CLI itself (which sends spec names), so this should be net positive.
- **`openFile.lineNumber`** is gone; the spec has no equivalent. Use `startText`/`endText` for position. Internal callers (`Send Selection`, sidebar commands) don't use `lineNumber` directly, but `call-bridge.js` examples updated.
- **`closeAllDiffTabs` return** went from object to string. `call-bridge.js` and any external scripts that JSON.parse'd the result need to handle a plain string.

## Testing

Local CI checks pass on the branch:
- `node --check` on the four JS files ✓
- `tests/validate-manifest.js` ✓
- `tests/handshake.test.js` ✓

Manual testing in Nova still needed before merge:
1. `Cmd+Ctrl+L` (send selection) — should still emit `selection_changed` + `at_mentioned` (no change to those paths)
2. `Cmd+Ctrl+A` (add file) — should still emit `at_mentioned` whole-file
3. Trigger Claude to call `openDiff` — verify diff staging UI + Accept/Reject flow returns `FILE_SAVED` / `DIFF_REJECTED`
4. Trigger Claude to call `openFile` with spec params — verify file opens and `startText`/`endText` selection works

## After merge

Out of scope for this PR; track separately:
- Bump `extension.json` 0.4.1 → 0.5.0
- Add CHANGELOG.md entry 0.5.0
- Tag `v0.5.0` + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)