### PR TITLE
feat: opt-in chat UI (Mode B) via Claude Agent SDK

### DIFF
--- a/claudecode-nova.novaextension/CHANGELOG.md
+++ b/claudecode-nova.novaextension/CHANGELOG.md
@@ -1,5 +1,95 @@
 # Changelog
 
+## 0.6.0 — 2026-05-28
+
+### Added
+- **Chat UI (Mode B — opt-in, experimental).** In-browser chat powered
+  by the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk` v0.3.x),
+  served on a fixed port (default 5180) by an HTTP+WS server embedded
+  in `ws-server.js`. Coexists with the existing CLI bridge (Mode A) —
+  both can run side-by-side. Open in Safari/Firefox or configure
+  Nova's Preview tab to use it inline. New command
+  `Claude Code: Open Claude Chat in Browser` shows an action panel
+  with Copy URL / Open in Browser actions.
+- **Twelve Nova editor tools exposed in-process to the SDK** via
+  `createSdkMcpServer({ tools: [...] })` — `nova_openFile`,
+  `nova_openDiff`, `nova_getCurrentSelection`, `nova_getLatestSelection`,
+  `nova_getOpenEditors`, `nova_getWorkspaceFolders`,
+  `nova_checkDocumentDirty`, `nova_saveDocument`, `nova_getDiagnostics`,
+  `nova_close_tab`, `nova_closeAllDiffTabs`, `nova_executeCode`. Each
+  wrapper round-trips through the existing `ws-server.js` ↔ `main.js`
+  JSON-line protocol via a shared `pendingRequests` map dispatched by
+  `kind: "mcp" | "chat"` — zero duplication of the editor-side
+  plumbing.
+- **1Password CLI key resolution** at extension activation.
+  `claudecode.chat.apiKey1PassRef` (e.g.
+  `op://Private/Anthropic API Key/credential`) runs `op read` to
+  fetch the Anthropic key without storing it in extension config or
+  Nova settings. Falls back to `claudecode.chat.apiKey` for users
+  without 1Password CLI.
+- **Cost-tuned defaults.** Sonnet 4.6 (default), `tools: []` (disables
+  the 115 built-in Claude Code tools), `settingSources: []` (SDK
+  isolation — no CLAUDE.md / skills / rules auto-load), wildcard
+  `allowedTools: ["mcp__nova__*"]` for trusted Nova tools. Typical
+  cost: ~$0.01–0.02 per multi-step interaction (vs ~$0.67 with
+  defaults).
+- **New config keys** : `claudecode.chat.enabled`,
+  `claudecode.chat.apiKey1PassRef`, `claudecode.chat.apiKey`,
+  `claudecode.chat.model` (Sonnet/Haiku/Opus), `claudecode.chat.port`.
+- **New sidebar section "Chat UI"** with the open-chat header
+  command — placeholder text for now, live status display planned.
+- **Claude Code CLI version check & update flow.** New command
+  `Claude Code: Check for Updates` (Extensions menu + sidebar header)
+  surfaces the installed CLI version, compares it against the npm
+  registry, and offers a one-click update with automatic bridge
+  stop/restart.
+- **Daily auto-check at activation**, throttled to 24h via
+  `claudecode.updateCheck.lastCheckedAt`. Silent on success, notifies
+  only when an update is available or when Claude Code is missing.
+  Toggle via the new `claudecode.updateCheck.autoCheck` setting.
+- **`stable` / `next` channel toggle** — `claudecode.updateCheck.channel`
+  picks which npm `dist-tag` to compare against. `next` surfaces
+  pre-releases; the comparator handles `X.Y.Z-beta.N` correctly (release
+  sorts higher than pre-release per semver).
+- **New sidebar section "Claude Code Version"** showing live state
+  (up-to-date / update available / not installed / unknown / checking)
+  with state-driven icon. Clicking the row triggers a check.
+- **"Not installed" UX** — when the CLI is absent, the notification
+  offers `Install Guide` (docs URL via `nova.openURL`),
+  `Configure Path` (opens extension settings on
+  `claudecode.claudeCommand`), `Install via npm` (only shown when `npm`
+  is on PATH), and `Don't Show Again` (sets
+  `claudecode.updateCheck.suppressNotInstalled`). The bridge keeps
+  running — Claude Code is only required to launch the CLI from Nova.
+- **Update execution prefers `claude update`** (the integrated updater),
+  falls back to `npm update -g @anthropic-ai/claude-code` or
+  `brew upgrade claude-code` based on the binary's resolved path. On
+  failure, the bridge is left **not** restarted so the user stays in a
+  stable state; a `Copy Log` action exposes stdout+stderr for triage.
+
+### Internal
+- New modules `Scripts/update-check.js` (~270 lines, pure logic — no
+  Nova globals beyond `Process` / `fetch` / `nova.fs.stat`) and
+  `Scripts/version-tree-provider.js` (~95 lines).
+- New chat backend modules `Scripts/chat-session.mjs` (HTTP+WS server,
+  SDK loop) and `Scripts/chat-tool-wrappers.mjs` (12 in-process tool
+  wrappers). Static chat UI in `Scripts/chat-ui/` (HTML/CSS/JS, no
+  build step ; marked + highlight.js via CDN for now).
+- `Scripts/package.json` declares chat deps : `@anthropic-ai/claude-agent-sdk`,
+  `ws`, `zod`. `node_modules/` ships ~50 MB unbundled ; esbuild
+  bundling deferred to a later release.
+- `Scripts/ws-server.js` extended : env-driven chat opt-in (`CC_CHAT_*`),
+  shared `pendingRequests` map with `kind` dispatch, lazy
+  `await import("./chat-session.mjs")` only when `chat.enabled=true`.
+- Both `main.js` (root) and `Scripts/main.js` updated; require paths
+  differ between the two (`./Scripts/…` vs `./…`) — only documented
+  delta to keep them functionally identical. Added `resolveChatApiKey()`,
+  `runOpRead()`, `openChatHandler()`, async `startBridge()`, and new
+  `chat_started` / `chat_failed` server-message dispatch.
+- Spike directories `spike/m0-node-pty/`, `spike/m1-agent-sdk/`,
+  `spike/m2-chat-ui/` archived in-repo for reference. Each contains
+  a `SPIKE.md` documenting findings ; `node_modules/` gitignored.
+
 ## 0.5.0 — 2026-05-15
 
 ### Changed

--- a/claudecode-nova.novaextension/Scripts/chat-session.mjs
+++ b/claudecode-nova.novaextension/Scripts/chat-session.mjs
@@ -1,0 +1,208 @@
+// chat-session.mjs — embedded chat server for the claudecode-nova extension.
+//
+// Loaded by ws-server.js when claudecode.chat.enabled is on. Spawns an HTTP
+// server (fixed port, configurable) that serves the chat UI assets in
+// ./chat-ui/ and exposes a WebSocket /ws endpoint. Drives Claude via the
+// Claude Agent SDK with in-process tool wrappers that round-trip Nova calls
+// through ws-server.js → main.js → editor.
+//
+// Lifecycle :
+//   1. ws-server.js calls init({ port, apiKey, callNovaTool, log })
+//   2. init starts the HTTP+WS server, returns a stop() function
+//   3. ws-server.js calls stop() on shutdown
+//
+// The chat server is INDEPENDENT of the MCP server — they share the Nova
+// round-trip plumbing (callNovaTool), but run on different ports and serve
+// different clients.
+
+import { createServer } from "http";
+import { readFile } from "fs/promises";
+import { dirname, extname, join } from "path";
+import { fileURLToPath } from "url";
+import { WebSocketServer } from "ws";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { buildNovaToolsServer } from "./chat-tool-wrappers.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHAT_UI_DIR = join(__dirname, "chat-ui");
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js":   "application/javascript; charset=utf-8",
+  ".mjs":  "application/javascript; charset=utf-8",
+  ".css":  "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg":  "image/svg+xml",
+  ".png":  "image/png",
+};
+
+/**
+ * Start the chat server. Returns a stop() function.
+ *
+ * @param {Object}   opts
+ * @param {number}   opts.port           HTTP port (e.g. 5180)
+ * @param {string}   opts.apiKey         Anthropic API key (already resolved)
+ * @param {string}   opts.model          "claude-sonnet-4-6", etc.
+ * @param {Function} opts.callNovaTool   async (toolName, args) → result (Phase 3)
+ * @param {Function} opts.log            (level, msg, data?) → void
+ */
+export async function init(opts) {
+  const { port, apiKey, model = "claude-sonnet-4-6", callNovaTool, log } = opts;
+
+  if (!apiKey) {
+    throw new Error("chat-session: apiKey is required");
+  }
+
+  // The SDK reads this from process.env (it's an env-driven API)
+  process.env.ANTHROPIC_API_KEY = apiKey;
+
+  const { server: novaServer, toolNames: allowedToolNames } = buildNovaToolsServer({ callNovaTool, log });
+  log("info", `chat: ${allowedToolNames.length} Nova tools exposed to SDK`);
+
+  // ── HTTP server (static files) ─────────────────────────────────
+  const httpServer = createServer(async (req, res) => {
+    try {
+      let path = (req.url || "/").split("?")[0];
+      if (path === "/") path = "/index.html";
+      if (path.includes("..")) {
+        res.writeHead(403); return res.end("Forbidden");
+      }
+      const filePath = join(CHAT_UI_DIR, path);
+      const data = await readFile(filePath);
+      const mime = MIME[extname(filePath)] || "application/octet-stream";
+      res.writeHead(200, { "content-type": mime, "cache-control": "no-cache" });
+      res.end(data);
+    } catch (err) {
+      if (err.code === "ENOENT") { res.writeHead(404); res.end("Not Found"); }
+      else { log("error", `chat http error: ${err.message}`); res.writeHead(500); res.end("Internal Error"); }
+    }
+  });
+
+  // ── WebSocket server ──────────────────────────────────────────
+  const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+
+  wss.on("connection", (socket, req) => {
+    log("info", `chat: ws client connected from ${req.socket.remoteAddress}`);
+
+    let currentAbortController = null;
+    let currentSessionId = null;
+
+    const send = (msg) => {
+      if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(msg));
+    };
+
+    socket.on("message", async (raw) => {
+      let msg;
+      try { msg = JSON.parse(raw.toString("utf8")); }
+      catch { send({ type: "error", message: "invalid JSON" }); return; }
+
+      if (msg.type === "abort") {
+        if (currentAbortController) {
+          currentAbortController.abort();
+          log("info", "chat: query aborted");
+        }
+        return;
+      }
+
+      if (msg.type !== "user_message" || typeof msg.text !== "string") {
+        send({ type: "error", message: "unsupported message type" });
+        return;
+      }
+
+      if (currentAbortController) {
+        send({ type: "error", message: "previous query still running" });
+        return;
+      }
+
+      currentAbortController = new AbortController();
+
+      try {
+        const q = query({
+          prompt: msg.text,
+          options: {
+            model,
+            tools: [],
+            settingSources: [],
+            mcpServers: { nova: novaServer },
+            allowedTools: allowedToolNames,
+            abortController: currentAbortController,
+            ...(currentSessionId ? { resume: currentSessionId } : {}),
+          },
+        });
+
+        for await (const event of q) {
+          switch (event.type) {
+            case "system":
+              if (event.subtype === "init") {
+                if (!currentSessionId) currentSessionId = event.session_id;
+                send({ type: "session_started", sessionId: event.session_id, model: event.model ?? model });
+              }
+              break;
+            case "assistant": {
+              const content = event.message?.content ?? [];
+              for (const block of content) {
+                if (block.type === "text") send({ type: "assistant_text", chunk: block.text });
+                else if (block.type === "tool_use") send({ type: "assistant_tool_use", name: block.name, input: block.input });
+              }
+              break;
+            }
+            case "user": {
+              const content = event.message?.content ?? [];
+              for (const block of content) {
+                if (block.type === "tool_result") {
+                  const text = Array.isArray(block.content)
+                    ? block.content.map((c) => c.text ?? "").join("")
+                    : (block.content ?? "");
+                  send({ type: "tool_result", name: block.name ?? "unknown", text, isError: !!block.is_error });
+                }
+              }
+              break;
+            }
+            case "result":
+              send({
+                type: "result",
+                success: event.subtype === "success",
+                cost: event.total_cost_usd ?? null,
+                tokens: event.usage ? { input: event.usage.input_tokens, output: event.usage.output_tokens } : null,
+                ...(event.subtype !== "success" ? { error: event.error ?? String(event) } : {}),
+              });
+              break;
+          }
+        }
+      } catch (err) {
+        if (err.name === "AbortError") {
+          send({ type: "error", message: "query aborted" });
+        } else {
+          log("error", `chat query error: ${err.message}`);
+          send({ type: "error", message: err.message || String(err) });
+        }
+      } finally {
+        currentAbortController = null;
+      }
+    });
+
+    socket.on("close", () => {
+      if (currentAbortController) currentAbortController.abort();
+      log("info", "chat: ws client disconnected");
+    });
+
+    socket.on("error", (err) => log("error", `chat ws socket error: ${err.message}`));
+  });
+
+  // ── Start listening ───────────────────────────────────────────
+  await new Promise((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(port, "127.0.0.1", () => {
+      log("info", `chat server listening on http://127.0.0.1:${port}/`);
+      resolve();
+    });
+  });
+
+  return {
+    port,
+    stop: () =>
+      new Promise((resolve) => {
+        wss.close(() => httpServer.close(() => resolve()));
+      }),
+  };
+}

--- a/claudecode-nova.novaextension/Scripts/chat-tool-wrappers.mjs
+++ b/claudecode-nova.novaextension/Scripts/chat-tool-wrappers.mjs
@@ -1,0 +1,157 @@
+// chat-tool-wrappers.mjs — in-process SDK tools that wrap the 12 Nova MCP
+// tools registered in ws-server.js.
+//
+// Each wrapper :
+//   1. Declares a Zod schema matching the JSON Schema in ws-server.js
+//   2. Calls `callNovaTool(mcpToolName, args)` which round-trips through
+//      ws-server.js → main.js → Nova editor and resolves with the MCP-shaped
+//      payload (already formatted by formatToolResultPayload in ws-server.js)
+//   3. Returns that payload to the SDK
+//
+// The SDK exposes these as `mcp__nova__<name>` ; the chat UI strips the
+// prefix for display.
+
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+/**
+ * Build an SDK MCP server exposing all Nova editor operations.
+ *
+ * @param {Object}   deps
+ * @param {Function} deps.callNovaTool  async (mcpToolName, args) → MCP payload
+ * @param {Function} deps.log           (level, msg) → void
+ */
+export function buildNovaToolsServer({ callNovaTool, log }) {
+  // Helper — every wrapper has the same shape, so factor it.
+  // `mcpName` is the name registered in ws-server.js (which main.js dispatches on).
+  function wrap(mcpName, description, schema) {
+    return tool(
+      `nova_${mcpName}`,
+      description,
+      schema,
+      async (args) => {
+        log("debug", `chat → nova.${mcpName}`, args);
+        try {
+          return await callNovaTool(mcpName, args);
+        } catch (err) {
+          return {
+            content: [{ type: "text", text: `Error calling ${mcpName}: ${err.message}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+
+  const tools = [
+    // ── File / editor navigation ─────────────────────────────────
+    wrap(
+      "openFile",
+      "Open a file in the Nova editor. Optionally select a text range by start/end pattern. Use this to show the user a file you're discussing.",
+      {
+        filePath:          z.string().describe("Path to the file to open (absolute or workspace-relative)"),
+        preview:           z.boolean().optional().describe("Open in preview tab"),
+        startText:         z.string().optional().describe("Text pattern marking selection start"),
+        endText:           z.string().optional().describe("Text pattern marking selection end"),
+        selectToEndOfLine: z.boolean().optional().describe("Extend selection to end of line"),
+        makeFrontmost:     z.boolean().optional().describe("Make the file the active editor tab"),
+      },
+    ),
+
+    wrap(
+      "openDiff",
+      "Open a git-style diff view in Nova showing proposed changes. Use this when proposing an edit so the user can accept or reject. Blocks until the user decides.",
+      {
+        old_file_path:     z.string().describe("Path to the original file"),
+        new_file_path:     z.string().describe("Path the new file will have (often same as old)"),
+        new_file_contents: z.string().describe("Full new content"),
+        tab_name:          z.string().describe("Name shown in the diff tab"),
+      },
+    ),
+
+    // ── Selection / current state ────────────────────────────────
+    wrap(
+      "getCurrentSelection",
+      "Get the user's current text selection in the active editor. Use this when the user refers to 'this code' or asks about something they're highlighting.",
+      {},
+    ),
+
+    wrap(
+      "getLatestSelection",
+      "Get the most recent text selection across editors, even if not currently in focus.",
+      {},
+    ),
+
+    wrap(
+      "getOpenEditors",
+      "List all currently open editor tabs in Nova, with their file paths and active state.",
+      {},
+    ),
+
+    wrap(
+      "getWorkspaceFolders",
+      "Get the workspace folder paths currently open in Nova. Use this to understand the project root.",
+      {},
+    ),
+
+    // ── Document state ───────────────────────────────────────────
+    wrap(
+      "checkDocumentDirty",
+      "Check whether a file has unsaved changes in Nova.",
+      {
+        filePath: z.string().describe("Path to the file"),
+      },
+    ),
+
+    wrap(
+      "saveDocument",
+      "Save a file in Nova (writes unsaved changes to disk).",
+      {
+        filePath: z.string().describe("Path to the file to save"),
+      },
+    ),
+
+    // ── Diagnostics ──────────────────────────────────────────────
+    wrap(
+      "getDiagnostics",
+      "Get language diagnostics (errors, warnings) from Nova. If uri is omitted, returns diagnostics for all open files.",
+      {
+        uri: z.string().optional().describe("File URI (file:// scheme) — omit for all files"),
+      },
+    ),
+
+    // ── Tab management ───────────────────────────────────────────
+    wrap(
+      "close_tab",
+      "Close a specific tab in Nova by its name.",
+      {
+        tab_name: z.string().describe("Name of the tab to close"),
+      },
+    ),
+
+    wrap(
+      "closeAllDiffTabs",
+      "Close all currently-open diff tabs in Nova at once.",
+      {},
+    ),
+
+    // ── Code execution (Jupyter-style — rarely used in chat) ─────
+    wrap(
+      "executeCode",
+      "Execute code on the current Jupyter kernel (only meaningful in a notebook context).",
+      {
+        code: z.string().describe("Code to execute"),
+      },
+    ),
+  ];
+
+  return {
+    server: createSdkMcpServer({
+      name: "nova",
+      version: "0.6.0",
+      tools,
+    }),
+    // The SDK exposes each as mcp__nova__<name> — needed for allowedTools
+    toolNames: tools.map((t) => `mcp__nova__${t.name}`),
+  };
+}

--- a/claudecode-nova.novaextension/Scripts/chat-ui/chat.css
+++ b/claudecode-nova.novaextension/Scripts/chat-ui/chat.css
@@ -1,0 +1,414 @@
+/* chat.css — dark theme, system font stack, no framework. */
+
+:root {
+  --bg:           #1e1e22;
+  --bg-elevated:  #26262b;
+  --bg-input:     #2a2a30;
+  --border:       #3a3a42;
+  --text:         #e8e8ea;
+  --text-muted:   #9a9aa3;
+  --accent:       #7c9eff;
+  --accent-warm:  #ffb454;
+  --user-bg:      #2e3a52;
+  --assistant-bg: #1e1e22;
+  --tool-bg:      #252027;
+  --tool-border:  #4a3a52;
+  --error:        #ff7676;
+  --success:      #6cd07a;
+
+  --radius:       8px;
+  --gap:          12px;
+  --code-bg:      #15151a;
+  --font-mono:    ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans:    -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── topbar ─────────────────────────────────────────────────────── */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  flex-shrink: 0;
+}
+
+.topbar__brand {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.topbar__sub {
+  margin-left: 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.topbar__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #555;
+}
+
+.dot--idle      { background: #555; }
+.dot--connected { background: var(--success); }
+.dot--thinking  { background: var(--accent); animation: pulse 1.2s infinite; }
+.dot--error     { background: var(--error); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+
+/* ── chat area ──────────────────────────────────────────────────── */
+
+.chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.chat__empty {
+  margin: auto;
+  text-align: left;
+  color: var(--text-muted);
+}
+
+.chat__empty-title {
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.chat__empty-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.suggestion {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.suggestion:hover {
+  border-color: var(--accent);
+  background: var(--bg-input);
+}
+
+.msg {
+  max-width: 880px;
+  width: 100%;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.msg__role {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.msg__body {
+  background: var(--assistant-bg);
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  word-wrap: break-word;
+}
+
+.msg--user .msg__body {
+  background: var(--user-bg);
+  border-color: #3a4a6a;
+}
+
+.msg--user {
+  align-self: flex-end;
+  max-width: 80%;
+}
+
+.msg__body p:first-child { margin-top: 0; }
+.msg__body p:last-child  { margin-bottom: 0; }
+
+.msg__body pre {
+  background: var(--code-bg);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 8px 0;
+  position: relative;
+}
+
+.msg__body code {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
+.msg__body :not(pre) > code {
+  background: var(--code-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12.5px;
+}
+
+.msg__body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  width: 100%;
+}
+
+.msg__body th, .msg__body td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+}
+
+.msg__body th {
+  background: var(--bg-elevated);
+}
+
+.msg__body blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 12px;
+  color: var(--text-muted);
+  margin: 8px 0;
+}
+
+/* ── code copy button ───────────────────────────────────────────── */
+
+.code-copy {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.msg__body pre:hover .code-copy { opacity: 1; }
+
+.code-copy:hover { color: var(--text); border-color: var(--accent); }
+.code-copy.copied { color: var(--success); border-color: var(--success); }
+
+/* ── tool call card ─────────────────────────────────────────────── */
+
+.tool {
+  background: var(--tool-bg);
+  border: 1px solid var(--tool-border);
+  border-radius: var(--radius);
+  padding: 0;
+  overflow: hidden;
+  max-width: 880px;
+  align-self: flex-start;
+}
+
+.tool__header {
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  background: var(--tool-bg);
+  user-select: none;
+}
+
+.tool__icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: var(--accent-warm);
+  flex-shrink: 0;
+}
+
+.tool__name {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--accent-warm);
+}
+
+.tool__summary {
+  color: var(--text-muted);
+  font-size: 12px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tool__caret {
+  color: var(--text-muted);
+  transition: transform 0.15s;
+}
+
+.tool.expanded .tool__caret { transform: rotate(90deg); }
+
+.tool__details {
+  display: none;
+  padding: 0 12px 12px;
+  border-top: 1px solid var(--tool-border);
+  margin-top: 4px;
+}
+
+.tool.expanded .tool__details { display: block; }
+
+.tool__section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 10px 0 4px;
+}
+
+.tool__pre {
+  background: var(--code-bg);
+  padding: 8px 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.tool.error .tool__icon { background: var(--error); }
+.tool.error .tool__name { color: var(--error); }
+
+/* ── composer ───────────────────────────────────────────────────── */
+
+.composer {
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: 10px 18px 14px;
+  flex-shrink: 0;
+}
+
+.composer__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-family: var(--font-mono);
+}
+
+.composer__row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+#input {
+  flex: 1;
+  resize: vertical;
+  min-height: 42px;
+  max-height: 200px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  padding: 10px 12px;
+}
+
+#input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.btn {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  font: inherit;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: var(--accent); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #15151a;
+  font-weight: 600;
+}
+
+.btn--primary:hover { background: #9bb5ff; }
+
+.btn--secondary {
+  background: var(--bg-input);
+  color: var(--error);
+  border-color: var(--error);
+}
+
+/* ── scrollbar ──────────────────────────────────────────────────── */
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #3a3a42; border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: #4a4a55; }
+
+/* ── error message ──────────────────────────────────────────────── */
+
+.error-msg {
+  color: var(--error);
+  font-size: 12px;
+  padding: 8px 12px;
+  background: rgba(255, 118, 118, 0.08);
+  border: 1px solid rgba(255, 118, 118, 0.3);
+  border-radius: var(--radius);
+  align-self: flex-start;
+  max-width: 880px;
+}

--- a/claudecode-nova.novaextension/Scripts/chat-ui/chat.js
+++ b/claudecode-nova.novaextension/Scripts/chat-ui/chat.js
@@ -1,0 +1,320 @@
+// chat.js — chat UI client: WebSocket + markdown render + tool cards + copy.
+//
+// Single-file vanilla JS. No bundler. Uses globals from CDN scripts :
+//   - marked (markdown parser)
+//   - hljs   (highlight.js)
+
+const $ = (id) => document.getElementById(id);
+
+const chatEl     = $("chat");
+const inputEl    = $("input");
+const sendBtn    = $("send");
+const abortBtn   = $("abort");
+const statusDot  = $("status-dot");
+const statusText = $("status-text");
+const emptyState = $("empty-state");
+const metaSess   = $("meta-session");
+const metaCost   = $("meta-cost");
+
+let ws = null;
+let inFlight = false;
+let currentAssistantBubble = null;
+let currentAssistantBuffer = "";
+let toolCardsByName = []; // queue of cards waiting for a matching tool_result
+
+// ── markdown render setup ─────────────────────────────────────────
+
+function setupMarked() {
+  if (typeof marked === "undefined") {
+    console.warn("marked not yet loaded — retrying");
+    return false;
+  }
+  marked.setOptions({
+    breaks: true,
+    gfm: true,
+  });
+  return true;
+}
+
+function renderMarkdown(text) {
+  if (typeof marked === "undefined") return escapeHtml(text);
+  return marked.parse(text);
+}
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function highlightCodeBlocks(rootEl) {
+  if (typeof hljs === "undefined") return;
+  rootEl.querySelectorAll("pre code").forEach((block) => {
+    if (block.dataset.highlighted) return;
+    hljs.highlightElement(block);
+    block.dataset.highlighted = "true";
+    addCopyButton(block.parentElement); // the <pre>
+  });
+}
+
+function addCopyButton(preEl) {
+  if (preEl.querySelector(".code-copy")) return;
+  const btn = document.createElement("button");
+  btn.className = "code-copy";
+  btn.textContent = "Copy";
+  btn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    const code = preEl.querySelector("code");
+    try {
+      await navigator.clipboard.writeText(code.innerText);
+      btn.textContent = "Copied!";
+      btn.classList.add("copied");
+      setTimeout(() => {
+        btn.textContent = "Copy";
+        btn.classList.remove("copied");
+      }, 1500);
+    } catch (err) {
+      btn.textContent = "Error";
+    }
+  });
+  preEl.appendChild(btn);
+}
+
+// ── DOM helpers for message bubbles ───────────────────────────────
+
+function hideEmptyState() {
+  if (emptyState) emptyState.style.display = "none";
+}
+
+function appendUserMessage(text) {
+  hideEmptyState();
+  const wrap = document.createElement("div");
+  wrap.className = "msg msg--user";
+  wrap.innerHTML = `
+    <div class="msg__role">You</div>
+    <div class="msg__body"></div>
+  `;
+  wrap.querySelector(".msg__body").textContent = text;
+  chatEl.appendChild(wrap);
+  scrollToBottom();
+}
+
+function ensureAssistantBubble() {
+  if (currentAssistantBubble) return currentAssistantBubble;
+  hideEmptyState();
+  const wrap = document.createElement("div");
+  wrap.className = "msg msg--assistant";
+  wrap.innerHTML = `
+    <div class="msg__role">Claude</div>
+    <div class="msg__body"></div>
+  `;
+  chatEl.appendChild(wrap);
+  currentAssistantBubble = wrap.querySelector(".msg__body");
+  currentAssistantBuffer = "";
+  return currentAssistantBubble;
+}
+
+function appendAssistantText(chunk) {
+  const body = ensureAssistantBubble();
+  currentAssistantBuffer += chunk;
+  body.innerHTML = renderMarkdown(currentAssistantBuffer);
+  highlightCodeBlocks(body);
+  scrollToBottom();
+}
+
+function appendToolCard(name, input) {
+  hideEmptyState();
+  // Close any open assistant bubble so the next assistant_text starts a new one
+  currentAssistantBubble = null;
+  currentAssistantBuffer = "";
+
+  const card = document.createElement("div");
+  card.className = "tool";
+  const summary = Object.keys(input).length
+    ? JSON.stringify(input)
+    : "(no args)";
+  card.innerHTML = `
+    <div class="tool__header" role="button">
+      <span class="tool__icon"></span>
+      <span class="tool__name">${escapeHtml(prettyToolName(name))}</span>
+      <span class="tool__summary">${escapeHtml(summary)}</span>
+      <span class="tool__caret">▶</span>
+    </div>
+    <div class="tool__details">
+      <div class="tool__section-label">Input</div>
+      <pre class="tool__pre">${escapeHtml(JSON.stringify(input, null, 2))}</pre>
+      <div class="tool__section-label tool__result-label" hidden>Result</div>
+      <pre class="tool__pre tool__result" hidden></pre>
+    </div>
+  `;
+  card.querySelector(".tool__header").addEventListener("click", () => {
+    card.classList.toggle("expanded");
+  });
+  chatEl.appendChild(card);
+  toolCardsByName.push({ name, card });
+  scrollToBottom();
+}
+
+function attachToolResult(name, text, isError) {
+  // Find the first card matching this name (FIFO matching)
+  const idx = toolCardsByName.findIndex((c) => c.name === name);
+  const target = idx >= 0 ? toolCardsByName.splice(idx, 1)[0].card : null;
+  if (!target) return;
+
+  if (isError) target.classList.add("error");
+
+  const label = target.querySelector(".tool__result-label");
+  const pre   = target.querySelector(".tool__result");
+  label.hidden = false;
+  pre.hidden = false;
+  pre.textContent = text;
+}
+
+function prettyToolName(name) {
+  // "mcp__nova__nova_openFile" → "nova_openFile"
+  return name.replace(/^mcp__[^_]+__/, "");
+}
+
+function appendErrorMessage(text) {
+  const el = document.createElement("div");
+  el.className = "error-msg";
+  el.textContent = "Error: " + text;
+  chatEl.appendChild(el);
+  scrollToBottom();
+}
+
+function scrollToBottom() {
+  chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+// ── WebSocket ─────────────────────────────────────────────────────
+
+function connect() {
+  const wsUrl = `ws://${location.host}/ws`;
+  ws = new WebSocket(wsUrl);
+  setStatus("idle", "Connecting…");
+
+  ws.addEventListener("open", () => {
+    setStatus("connected", "Ready");
+  });
+
+  ws.addEventListener("close", () => {
+    setStatus("error", "Disconnected — reconnecting…");
+    setTimeout(connect, 1500);
+  });
+
+  ws.addEventListener("error", () => {
+    setStatus("error", "WebSocket error");
+  });
+
+  ws.addEventListener("message", (event) => {
+    let msg;
+    try { msg = JSON.parse(event.data); }
+    catch { return; }
+    handleServerMessage(msg);
+  });
+}
+
+function handleServerMessage(msg) {
+  switch (msg.type) {
+    case "session_started":
+      metaSess.textContent = `session ${msg.sessionId.slice(0, 8)}… · model ${msg.model}`;
+      setStatus("thinking", "Claude is working…");
+      break;
+
+    case "assistant_text":
+      appendAssistantText(msg.chunk);
+      break;
+
+    case "assistant_tool_use":
+      appendToolCard(msg.name, msg.input);
+      break;
+
+    case "tool_result":
+      attachToolResult(msg.name, msg.text, msg.isError);
+      break;
+
+    case "result":
+      setStatus("connected", "Ready");
+      inFlight = false;
+      abortBtn.hidden = true;
+      sendBtn.disabled = false;
+      currentAssistantBubble = null;
+      currentAssistantBuffer = "";
+      if (msg.success && msg.cost != null) {
+        const tk = msg.tokens
+          ? ` · in ${msg.tokens.input} / out ${msg.tokens.output} tk`
+          : "";
+        metaCost.textContent = `last cost $${msg.cost.toFixed(4)}${tk}`;
+      } else if (!msg.success) {
+        appendErrorMessage(msg.error || "query failed");
+      }
+      break;
+
+    case "error":
+      appendErrorMessage(msg.message);
+      setStatus("connected", "Ready");
+      inFlight = false;
+      abortBtn.hidden = true;
+      sendBtn.disabled = false;
+      break;
+  }
+}
+
+function setStatus(kind, text) {
+  statusDot.className = "dot dot--" + kind;
+  statusText.textContent = text;
+}
+
+// ── send flow ─────────────────────────────────────────────────────
+
+function sendUserMessage() {
+  const text = inputEl.value.trim();
+  if (!text || inFlight || !ws || ws.readyState !== WebSocket.OPEN) return;
+  inFlight = true;
+  appendUserMessage(text);
+  ws.send(JSON.stringify({ type: "user_message", text }));
+  inputEl.value = "";
+  sendBtn.disabled = true;
+  abortBtn.hidden = false;
+  setStatus("thinking", "Sending…");
+}
+
+function abortQuery() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "abort" }));
+}
+
+// ── input wiring ──────────────────────────────────────────────────
+
+sendBtn.addEventListener("click", sendUserMessage);
+abortBtn.addEventListener("click", abortQuery);
+
+inputEl.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    sendUserMessage();
+  }
+});
+
+document.querySelectorAll(".suggestion").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    inputEl.value = btn.dataset.prompt;
+    sendUserMessage();
+  });
+});
+
+// ── boot ──────────────────────────────────────────────────────────
+
+window.addEventListener("load", () => {
+  // Wait for marked + hljs to be available
+  const tryStart = () => {
+    if (setupMarked() && typeof hljs !== "undefined") {
+      connect();
+    } else {
+      setTimeout(tryStart, 80);
+    }
+  };
+  tryStart();
+});

--- a/claudecode-nova.novaextension/Scripts/chat-ui/index.html
+++ b/claudecode-nova.novaextension/Scripts/chat-ui/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Claude Code · Nova chat (M2 demo)</title>
+  <link rel="stylesheet" href="chat.css" />
+  <!-- highlight.js for code blocks (atom-one-dark theme) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/styles/atom-one-dark.min.css" />
+  <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/highlight.min.js"></script>
+  <!-- marked for markdown rendering -->
+  <script defer src="https://cdn.jsdelivr.net/npm/marked@13.0.3/marked.min.js"></script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar__title">
+      <span class="topbar__brand">Claude Code · Nova</span>
+      <span class="topbar__sub">M2 chat UI demo</span>
+    </div>
+    <div class="topbar__status" id="status">
+      <span class="dot dot--idle" id="status-dot"></span>
+      <span id="status-text">Connecting…</span>
+    </div>
+  </header>
+
+  <main class="chat" id="chat">
+    <div class="chat__empty" id="empty-state">
+      <div class="chat__empty-title">Try something like :</div>
+      <ul class="chat__empty-list">
+        <li><button class="suggestion" data-prompt="List the files in the workspace and tell me what this project does.">List the files in the workspace and tell me what this project does.</button></li>
+        <li><button class="suggestion" data-prompt="Read src/auth.ts and identify any security issues.">Read src/auth.ts and identify any security issues.</button></li>
+        <li><button class="suggestion" data-prompt="Get the diagnostics for src/auth.ts.">Get the diagnostics for src/auth.ts.</button></li>
+      </ul>
+    </div>
+  </main>
+
+  <footer class="composer">
+    <div class="composer__meta" id="meta">
+      <span id="meta-session"></span>
+      <span id="meta-cost"></span>
+    </div>
+    <div class="composer__row">
+      <textarea
+        id="input"
+        placeholder="Ask Claude…  (Enter to send, Shift+Enter for newline)"
+        rows="2"
+        autofocus
+      ></textarea>
+      <button id="send" class="btn btn--primary" title="Send (Enter)">Send</button>
+      <button id="abort" class="btn btn--secondary" title="Abort current query" hidden>Stop</button>
+    </div>
+  </footer>
+
+  <script type="module" src="chat.js"></script>
+</body>
+</html>

--- a/claudecode-nova.novaextension/Scripts/main.js
+++ b/claudecode-nova.novaextension/Scripts/main.js
@@ -7,7 +7,13 @@
  *   3. Maps MCP tool calls to Nova editor APIs
  *   4. Tracks editor selection and broadcasts changes
  *   5. Provides sidebar UI and commands
+ *   6. Checks the Claude Code CLI for updates (manual + 24h auto)
  */
+
+const UpdateCheck = require("./update-check.js");
+const { VersionTreeProvider } = require("./version-tree-provider.js");
+
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h auto-check throttle
 
 // ---------------------------------------------------------------------------
 // State
@@ -42,6 +48,21 @@ let gitBranch = null;
 let gitBranchTimer = null;
 const GIT_BRANCH_REFRESH_MS = 5 * 60 * 1000;
 
+// Claude Code CLI version state. Mutated by checkForUpdates() and read by
+// the sidebar provider — same object reference passed both ways so the
+// provider always reflects the latest snapshot after a reload().
+let versionState = {
+  state: "unknown",
+  currentVersion: null,
+  latestVersion: null,
+  channel: "stable",
+  lastCheckedAt: null,
+  message: null,
+};
+let versionProvider = null;
+let versionTree = null;
+let updateInProgress = false;
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -64,6 +85,8 @@ exports.activate = function() {
       nova.commands.register("claudecode.diffReject", diffRejectHandler),
       nova.commands.register("claudecode.diffShowDetails", diffShowDetailsHandler),
       nova.commands.register("claudecode.sidebarRefresh", sidebarRefreshHandler),
+      nova.commands.register("claudecode.checkForUpdates", function() { checkForUpdates(false); }),
+      nova.commands.register("claudecode.openChat", openChatHandler),
     );
     console.log("Claude Code Bridge: commands registered");
   } catch (err) {
@@ -83,13 +106,16 @@ exports.activate = function() {
 
   const autoStart = nova.config.get("claudecode.autoStart");
   if (autoStart !== false) {
-    try {
-      startBridge();
-    } catch (err) {
+    // Chat key resolution may need an `op read` round-trip, so startBridge is
+    // now async. Fire-and-forget — no caller awaits the return.
+    startBridge().catch((err) => {
       console.error("Claude Code Bridge: startBridge() failed:", err.message, err.stack || "");
       showNotification("Error", `Failed to start bridge: ${err.message}`);
-    }
+    });
   }
+
+  // Fire-and-forget: never block activate() on a network round-trip.
+  maybeAutoCheckUpdates();
 
   console.log("Claude Code Bridge: activation complete");
 };
@@ -139,10 +165,96 @@ function resolveNodePath() {
 }
 
 // ---------------------------------------------------------------------------
+// Chat (Mode B) — opt-in chat UI helpers
+// ---------------------------------------------------------------------------
+
+// Resolve the Anthropic API key for chat mode. Tries 1Password CLI first
+// (via `op read <ref>`), falls back to the direct config value. Returns
+// the key string, or empty string if no source is configured / op fails.
+async function resolveChatApiKey() {
+  const opRef  = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
+  const direct = (nova.config.get("claudecode.chat.apiKey") || "").trim();
+
+  if (opRef) {
+    try {
+      const key = await runOpRead(opRef);
+      if (key) return key;
+    } catch (err) {
+      console.warn("Claude Code Bridge: op read failed (" + err.message + ") — falling back to direct key");
+    }
+  }
+
+  return direct;
+}
+
+// Run `op read <ref>` and capture stdout. Resolves with the trimmed output
+// on exit 0, rejects on non-zero exit or spawn failure.
+function runOpRead(ref) {
+  return new Promise((resolve, reject) => {
+    const proc = new Process("/usr/bin/env", {
+      args: ["op", "read", ref],
+      shell: false,
+      stdio: "pipe",
+    });
+    let out = "";
+    let err = "";
+    proc.onStdout(function(chunk) { out += chunk; });
+    proc.onStderr(function(chunk) { err += chunk; });
+    proc.onDidExit(function(code) {
+      if (code === 0) resolve(out.trim());
+      else reject(new Error("op exit code " + code + ": " + err.trim()));
+    });
+    try {
+      proc.start();
+    } catch (spawnErr) {
+      reject(new Error("Cannot spawn op CLI: " + spawnErr.message));
+    }
+  });
+}
+
+// "Open Claude Chat in Browser" command — shows the chat URL with copy and
+// browser-open actions. Guides the user to configure Nova Project Settings
+// (Preview URL) so the chat can live inside Nova's Preview tab.
+function openChatHandler() {
+  if (!nova.config.get("claudecode.chat.enabled")) {
+    nova.workspace.showActionPanel(
+      "Chat UI is currently disabled.",
+      { buttons: ["Open Settings", "Cancel"] },
+      function(idx) {
+        if (idx === 0) nova.openConfig(nova.extension.identifier);
+      },
+    );
+    return;
+  }
+
+  const port = nova.config.get("claudecode.chat.port") || 5180;
+  const url  = "http://127.0.0.1:" + port + "/";
+
+  nova.workspace.showActionPanel(
+    "Claude Chat UI\n\n" + url + "\n\nTo use inside Nova's Preview tab, configure\nProject Settings → Web → Preview URL to the URL above.",
+    { buttons: ["Copy URL", "Open in Browser", "Close"] },
+    function(idx) {
+      if (idx === 0) {
+        nova.clipboard.writeText(url);
+        showNotification("Copied", url + " is in your clipboard.");
+      } else if (idx === 1) {
+        // Best-effort: spawn `open <url>` (macOS) to launch the default browser.
+        try {
+          const proc = new Process("/usr/bin/open", { args: [url], stdio: "ignore" });
+          proc.start();
+        } catch (err) {
+          showNotification("Cannot open browser", err.message);
+        }
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Bridge lifecycle
 // ---------------------------------------------------------------------------
 
-function startBridge() {
+async function startBridge() {
   if (serverProcess) {
     console.log("Claude Code Bridge: already running");
     showNotification("Already Running", "Claude Code Bridge is already active.");
@@ -161,14 +273,40 @@ function startBridge() {
   console.log("  Script: " + scriptPath);
   console.log("  Workspace: " + workspace);
 
+  // Build env. If chat (Mode B) is opt-in, resolve the API key first
+  // (1Password reference or direct config value) and add the CC_CHAT_* vars
+  // so ws-server.js lazy-loads chat-session.mjs at startup.
+  const env = {
+    CC_PORT_MIN: String(portMin),
+    CC_PORT_MAX: String(portMax),
+    CC_WORKSPACE: workspace,
+  };
+
+  if (nova.config.get("claudecode.chat.enabled")) {
+    try {
+      const apiKey = await resolveChatApiKey();
+      if (apiKey) {
+        env.CC_CHAT_ENABLED = "1";
+        env.CC_CHAT_PORT    = String(nova.config.get("claudecode.chat.port") || 5180);
+        env.CC_CHAT_MODEL   = nova.config.get("claudecode.chat.model") || "claude-sonnet-4-6";
+        env.ANTHROPIC_API_KEY = apiKey;
+        console.log("Claude Code Bridge: chat enabled, port " + env.CC_CHAT_PORT + ", model " + env.CC_CHAT_MODEL);
+      } else {
+        console.warn("Claude Code Bridge: chat enabled but no API key resolved — chat will be disabled");
+        showNotification(
+          "Chat key missing",
+          "Chat UI is enabled but no Anthropic API key was found.\nConfigure 'Anthropic API Key — 1Password reference' or the direct key in Extension Settings."
+        );
+      }
+    } catch (err) {
+      console.error("Claude Code Bridge: chat API key resolution failed:", err.message);
+    }
+  }
+
   try {
     serverProcess = new Process(nodePath, {
       args: [scriptPath],
-      env: {
-        CC_PORT_MIN: String(portMin),
-        CC_PORT_MAX: String(portMax),
-        CC_WORKSPACE: workspace,
-      },
+      env,
       cwd: workspace || undefined,
       stdio: "pipe",
     });
@@ -320,6 +458,19 @@ function handleServerMessage(msg) {
       } else {
         console.log("[ws-server] " + msg.message);
       }
+      break;
+
+    case "chat_started":
+      console.log("Claude Code Bridge: chat server started on port " + msg.port);
+      showNotification(
+        "Chat UI ready",
+        "Claude chat is live at http://127.0.0.1:" + msg.port + "/.\nUse \"Open Claude Chat in Browser\" command to open it, or configure Nova Project Settings → Preview URL."
+      );
+      break;
+
+    case "chat_failed":
+      console.error("Claude Code Bridge: chat server failed — " + msg.message);
+      showNotification("Chat UI failed to start", msg.message);
       break;
   }
 }
@@ -1035,9 +1186,21 @@ function ensureActivitySidebars() {
       });
       disposables.push(activityTree);
     }
+    if (!versionProvider) {
+      versionProvider = new VersionTreeProvider(versionState);
+      versionTree = new TreeView("claudecode.sidebar.version", {
+        dataProvider: versionProvider,
+      });
+      disposables.push(versionTree);
+    }
   } catch (err) {
     console.error("Claude Code Bridge: activity sidebar init failed:", err.message);
   }
+}
+
+function refreshVersionSidebar() {
+  ensureActivitySidebars();
+  try { if (versionTree) versionTree.reload(); } catch (_) {}
 }
 
 // Reload both activity-related sections. Called after every event that
@@ -1624,6 +1787,286 @@ function runAppleScript(script) {
       reject(err);
     }
   });
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code CLI version check & update
+// ---------------------------------------------------------------------------
+//
+// Three entry points feed the same pipeline:
+//   1. activate() → maybeAutoCheckUpdates() — silent, throttled to 24h.
+//   2. Command "Claude Code: Check for Updates" → checkForUpdates(false).
+//   3. Sidebar click on the version row → checkForUpdates(false).
+//
+// `silent=true` suppresses all notifications EXCEPT the "update available"
+// one — that's the whole point of the daily auto-check.
+
+function maybeAutoCheckUpdates() {
+  if (nova.config.get("claudecode.updateCheck.autoCheck") === false) return;
+  const last = nova.config.get("claudecode.updateCheck.lastCheckedAt") || 0;
+  if (Date.now() - last < UPDATE_CHECK_INTERVAL_MS) return;
+  checkForUpdates(true).catch(function(err) {
+    console.warn("Claude Code Bridge: auto-check failed:", err.message);
+  });
+}
+
+async function checkForUpdates(silent) {
+  const claudeCommand = nova.workspace.config.get("claudecode.claudeCommand") || "claude";
+  const channel = nova.config.get("claudecode.updateCheck.channel") || "stable";
+  versionState.channel = channel;
+
+  if (!silent) {
+    versionState.state = "checking";
+    versionState.message = null;
+    refreshVersionSidebar();
+  }
+
+  let current;
+  try {
+    current = await UpdateCheck.getCurrentVersion(claudeCommand);
+  } catch (err) {
+    console.error("Claude Code Bridge: getCurrentVersion failed:", err.message);
+    versionState.state = "error";
+    versionState.message = err.message;
+    refreshVersionSidebar();
+    if (!silent) showNotification("Update Check Failed", err.message);
+    persistLastChecked();
+    return;
+  }
+
+  if (current.state === "not_installed") {
+    versionState.state = "not_installed";
+    versionState.currentVersion = null;
+    versionState.message = "Claude Code CLI was not found on PATH.";
+    refreshVersionSidebar();
+    presentNotInstalled(silent);
+    persistLastChecked();
+    return;
+  }
+
+  if (current.state === "unknown") {
+    versionState.state = "unknown";
+    versionState.currentVersion = null;
+    versionState.message = current.error || current.raw || "Unparsable version output.";
+    refreshVersionSidebar();
+    if (!silent) {
+      showNotification("Version Unknown",
+        "Could not parse `claude --version` output: " + versionState.message);
+    }
+    persistLastChecked();
+    return;
+  }
+
+  versionState.currentVersion = current.version;
+
+  let latest;
+  try {
+    latest = await UpdateCheck.getLatestVersion(channel);
+  } catch (err) {
+    versionState.state = "error";
+    versionState.message = err.message;
+    refreshVersionSidebar();
+    if (!silent) showNotification("Update Check Failed", err.message);
+    persistLastChecked();
+    return;
+  }
+
+  versionState.latestVersion = latest.version;
+  const cmp = UpdateCheck.semverCompare(current.version, latest.version);
+  persistLastChecked();
+
+  if (cmp === null) {
+    versionState.state = "unknown";
+    versionState.message = "Could not compare versions (" + current.version + " vs " + latest.version + ").";
+    refreshVersionSidebar();
+    return;
+  }
+
+  if (cmp >= 0) {
+    versionState.state = "up_to_date";
+    versionState.message = null;
+    refreshVersionSidebar();
+    if (!silent) {
+      showNotification("Up to Date", "Claude Code is up to date (v" + current.version + ").");
+    }
+    return;
+  }
+
+  // Update available — always notify, even on silent auto-check.
+  versionState.state = "update_available";
+  versionState.message = "Update available: v" + current.version + " → v" + latest.version;
+  refreshVersionSidebar();
+  presentUpdateAvailable(current, latest);
+}
+
+function presentUpdateAvailable(current, latest) {
+  const req = new NotificationRequest("claudecode-update-available");
+  req.title = "Claude Code Update Available";
+  req.body = "v" + current.version + " → v" + latest.version + ".\nUpdate will stop and restart the bridge.";
+  req.actions = ["Update Now", "Release Notes", "Later"];
+
+  nova.notifications.add(req).then(function(response) {
+    if (response.actionIdx === 0) {
+      const method = UpdateCheck.detectInstallMethod(current.path);
+      runUpdateFlow(method);
+    } else if (response.actionIdx === 1) {
+      const url = "https://github.com/anthropics/claude-code/releases/tag/v" + latest.version;
+      try { nova.openURL(url); }
+      catch (err) {
+        nova.clipboard.writeText(url);
+        showNotification("Release Notes", "URL copied to clipboard: " + url);
+      }
+    }
+    // "Later" → no-op; user can re-check via the sidebar or command.
+  });
+}
+
+async function presentNotInstalled(silent) {
+  if (silent && nova.config.get("claudecode.updateCheck.suppressNotInstalled") === true) {
+    return;
+  }
+
+  const npmOk = !silent && (await UpdateCheck.isNpmAvailable());
+
+  const req = new NotificationRequest("claudecode-not-installed");
+  req.title = "Claude Code CLI Not Found";
+  req.body = "The Claude Code CLI is not on PATH. The bridge runs without it, but you'll need it to launch Claude from Nova.";
+  req.actions = ["Install Guide", "Configure Path"];
+  if (npmOk) req.actions.push("Install via npm");
+  if (silent) req.actions.push("Don't Show Again");
+
+  nova.notifications.add(req).then(function(response) {
+    const action = req.actions[response.actionIdx];
+    if (action === "Install Guide") {
+      const url = "https://docs.anthropic.com/claude-code/install";
+      try { nova.openURL(url); }
+      catch (_) {
+        nova.clipboard.writeText(url);
+        showNotification("Install Guide", "URL copied to clipboard: " + url);
+      }
+    } else if (action === "Configure Path") {
+      try { nova.workspace.openConfig(nova.extension.identifier); }
+      catch (err) {
+        showNotification("Open Settings", "Could not open extension settings: " + err.message);
+      }
+    } else if (action === "Install via npm") {
+      runInstallFlow();
+    } else if (action === "Don't Show Again") {
+      nova.config.set("claudecode.updateCheck.suppressNotInstalled", true);
+    }
+  });
+}
+
+async function runUpdateFlow(method) {
+  if (updateInProgress) {
+    showNotification("Update In Progress", "An update is already running.");
+    return;
+  }
+  updateInProgress = true;
+
+  const wasRunning = !!serverProcess;
+  if (wasRunning) {
+    stopBridge();
+    await delay(500); // give the OS a moment to release the port
+  }
+
+  showNotification("Updating", "Updating Claude Code… the bridge will restart automatically.");
+  const claudeCommand = nova.workspace.config.get("claudecode.claudeCommand") || "claude";
+
+  let result;
+  try {
+    result = await UpdateCheck.runUpdate(method, claudeCommand);
+  } catch (err) {
+    console.error("Claude Code Bridge: update threw:", err.message);
+    result = { success: false, stderr: err.message };
+  }
+
+  updateInProgress = false;
+
+  if (result.success) {
+    // Re-probe the new version so the sidebar reflects reality.
+    try {
+      const current = await UpdateCheck.getCurrentVersion(claudeCommand);
+      if (current.state === "installed") {
+        versionState.currentVersion = current.version;
+        versionState.state = "up_to_date";
+        versionState.message = null;
+        refreshVersionSidebar();
+      }
+    } catch (_) {}
+
+    showNotification("Update Complete",
+      "Claude Code updated successfully" +
+      (versionState.currentVersion ? " to v" + versionState.currentVersion : "") + ".");
+
+    if (wasRunning) {
+      setTimeout(function() {
+        try { startBridge(); } catch (err) {
+          console.error("Claude Code Bridge: post-update restart failed:", err.message);
+          showNotification("Restart Failed", "Update succeeded but bridge restart failed: " + err.message);
+        }
+      }, 300);
+    }
+  } else {
+    // Don't auto-restart the bridge on failure — leave the user in a stable
+    // state so they can diagnose. The previous claude is still installed.
+    const stderr = (result.stderr || "").trim();
+    const req = new NotificationRequest("claudecode-update-failed");
+    req.title = "Claude Code Update Failed";
+    req.body = stderr ? stderr.slice(0, 500) : "Update command returned a non-zero exit code.";
+    req.actions = ["Copy Log", "OK"];
+    nova.notifications.add(req).then(function(response) {
+      if (response.actionIdx === 0) {
+        const full = "stdout:\n" + (result.stdout || "") + "\n\nstderr:\n" + (result.stderr || "");
+        nova.clipboard.writeText(full);
+      }
+    });
+  }
+}
+
+async function runInstallFlow() {
+  if (updateInProgress) {
+    showNotification("Install In Progress", "An install is already running.");
+    return;
+  }
+  updateInProgress = true;
+  showNotification("Installing", "Installing @anthropic-ai/claude-code globally via npm…");
+
+  let result;
+  try {
+    result = await UpdateCheck.installViaNpm();
+  } catch (err) {
+    result = { success: false, stderr: err.message };
+  }
+  updateInProgress = false;
+
+  if (result.success) {
+    showNotification("Install Complete", "Claude Code installed. Run \"Check for Updates\" to refresh the sidebar.");
+    // Trigger a re-check so the sidebar updates without user action.
+    checkForUpdates(true).catch(function(_) {});
+  } else {
+    const req = new NotificationRequest("claudecode-install-failed");
+    req.title = "Install Failed";
+    req.body = (result.stderr || "npm install exited with a non-zero code.").slice(0, 500);
+    req.actions = ["Copy Log", "OK"];
+    nova.notifications.add(req).then(function(response) {
+      if (response.actionIdx === 0) {
+        nova.clipboard.writeText("stdout:\n" + (result.stdout || "") + "\n\nstderr:\n" + (result.stderr || ""));
+      }
+    });
+  }
+}
+
+function persistLastChecked() {
+  try {
+    nova.config.set("claudecode.updateCheck.lastCheckedAt", Date.now());
+    if (versionState.currentVersion) {
+      nova.config.set("claudecode.updateCheck.lastSeenVersion", versionState.currentVersion);
+    }
+  } catch (err) {
+    console.warn("Claude Code Bridge: could not persist lastCheckedAt:", err.message);
+  }
+  versionState.lastCheckedAt = Date.now();
 }
 
 // ---------------------------------------------------------------------------

--- a/claudecode-nova.novaextension/Scripts/package-lock.json
+++ b/claudecode-nova.novaextension/Scripts/package-lock.json
@@ -1,0 +1,1475 @@
+{
+  "name": "claudecode-nova-scripts",
+  "version": "0.6.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claudecode-nova-scripts",
+      "version": "0.6.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "ws": "^8.18.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.153.tgz",
+      "integrity": "sha512-+WYWQ5ih2dOuiJY4yql5pje3w8iA+aS7eZXJSFo6LZxmEiH4nV4n/fjhJCWPcqyo7TdvhAjS2cPqwIslNw3c7A==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.153.tgz",
+      "integrity": "sha512-4K2K/n/qikp24ufO38owSEj5RPMWjBmf83BSUxLlzOhOXt7dHXs1CitmY9ZYM58Wmn3qhJs9DaS//ptO1siskQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.153.tgz",
+      "integrity": "sha512-kY5DPMAK+ZkphoIUjOiP6sSB57Lw2H1RUNK2HVEDowagbl9T47DSbkjYE4NWYqfy22aebPj02VAIbFfFmYxnMw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.153.tgz",
+      "integrity": "sha512-XoIP6xJn+QlfBta96yfxdtaeJ/BstA2S9abZJYeWs/wwNjQNWs83repg/v1VPuGn7i44teSzLtzoAv9t1w4Ybg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.153.tgz",
+      "integrity": "sha512-5fD6MagyX+1tZdpVjZ6rN178pR7K10c+JyTsEh4HUJR3tnVO9uZYcmEcsKLX1TjWX+mz5+TW9rwDP5AMHXsjNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.153.tgz",
+      "integrity": "sha512-U2eY8iBLF0vrvuHnh33UA3LA/aIVgSk2Pw5KY7N5lH5fYzcnDBoT8bG32lelQIoaUDY0znOWIc0vqN5/Yih51w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.153.tgz",
+      "integrity": "sha512-4o+1RnNAL31iZDDT46AWl/t5lUSVJ5Gq8o2IxPgNBltPHAL3aUmTTDLxjDb+gFVEyegyy9FwK0yPJGpNp4CxKA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.153.tgz",
+      "integrity": "sha512-GQsZTvf4pJVVAgaXwpN/W7RpO7dtUd3VCM3zxD7RQ1X+Dc8tUNPMWr7JCHEYwrUWiS1jeSjLOsrAuRFopSP43Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.153",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.153.tgz",
+      "integrity": "sha512-t/+IEFLsp+fY1G5EZhzVBNKI1mm28rPNcyrlJHy3wCbl1aA/Myd7mWnNCRckDGENZz4V7KyqCslLsCt5gT2iPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.99.0.tgz",
+      "integrity": "sha512-vdicFA9YjtvgpG8rxp39hqW4oxpkdRGPTq0QEts5TZhr2GkLozDduK/GiXrLQ7PzrKYBtIkQFdRW+QBjzlsABg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/claudecode-nova.novaextension/Scripts/package.json
+++ b/claudecode-nova.novaextension/Scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "claudecode-nova-scripts",
+  "version": "0.6.0",
+  "private": true,
+  "type": "commonjs",
+  "description": "Node subprocess scripts for the Claude Code Nova extension. ws-server.js is CommonJS (uses node built-ins only). chat-session.mjs is ES Modules (uses SDK).",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "ws": "^8.18.0",
+    "zod": "^4.0.0"
+  }
+}

--- a/claudecode-nova.novaextension/Scripts/update-check.js
+++ b/claudecode-nova.novaextension/Scripts/update-check.js
@@ -1,0 +1,323 @@
+/**
+ * update-check.js — version detection, comparison, and update execution for
+ * the Claude Code CLI. Runs in Nova's JavaScriptCore runtime (not Node), so
+ * everything uses Nova's Process / fetch / nova.fs APIs.
+ *
+ * Exports:
+ *   getCurrentVersion(claudeCommand) → Promise<CurrentVersionResult>
+ *   getLatestVersion(channel)        → Promise<LatestVersionResult>
+ *   detectInstallMethod(claudePath)  → "npm" | "homebrew" | "standalone" | "unknown"
+ *   resolveClaudePath(claudeCommand) → Promise<string | null>
+ *   isNpmAvailable()                 → Promise<boolean>
+ *   runUpdate(method, claudeCommand) → Promise<UpdateResult>
+ *   semverCompare(a, b)              → number | null
+ *
+ * State values for getCurrentVersion:
+ *   "installed"     — binary present, version parsed
+ *   "not_installed" — ENOENT / command not found
+ *   "unknown"       — present but version output not parsable
+ */
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/@anthropic-ai/claude-code";
+const FETCH_TIMEOUT_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Semver
+// ---------------------------------------------------------------------------
+
+function parseSemver(v) {
+  if (!v || typeof v !== "string") return null;
+  const m = v.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([\w.]+))?$/);
+  if (!m) return null;
+  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] || null };
+}
+
+// Returns negative if a<b, 0 if equal, positive if a>b, null if unparsable.
+// Per semver: X.Y.Z > X.Y.Z-anything (releases sort higher than pre-releases).
+function semverCompare(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  const core = (pa.major - pb.major) || (pa.minor - pb.minor) || (pa.patch - pb.patch);
+  if (core !== 0) return core;
+  if (pa.pre === pb.pre) return 0;
+  if (pa.pre === null) return 1;
+  if (pb.pre === null) return -1;
+  return pa.pre < pb.pre ? -1 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// Process helper — captures stdout, stderr, exit code without throwing.
+// Returns { code, stdout, stderr, spawnError? }.
+// ---------------------------------------------------------------------------
+
+function runProcess(command, args, options) {
+  return new Promise(function(resolve) {
+    let proc;
+    try {
+      proc = new Process(command, Object.assign({
+        args: args || [],
+        shell: false,
+        stdio: "pipe",
+      }, options || {}));
+    } catch (err) {
+      resolve({ code: -1, stdout: "", stderr: "", spawnError: err.message });
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    proc.onStdout(function(chunk) { stdout += chunk; });
+    proc.onStderr(function(chunk) { stderr += chunk; });
+    proc.onDidExit(function(code) {
+      resolve({ code: code, stdout: stdout, stderr: stderr });
+    });
+
+    try {
+      proc.start();
+    } catch (err) {
+      resolve({ code: -1, stdout: "", stderr: "", spawnError: err.message });
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Resolve claude binary path via `which`
+// ---------------------------------------------------------------------------
+
+async function resolveClaudePath(claudeCommand) {
+  const cmd = claudeCommand || "claude";
+
+  // If the user configured an absolute path, take it at face value if it
+  // exists on disk. Avoids a spurious `which` call.
+  if (cmd.startsWith("/")) {
+    try {
+      if (nova.fs.stat(cmd)) return cmd;
+    } catch (_) {}
+    return null;
+  }
+
+  const result = await runProcess("/usr/bin/which", [cmd]);
+  if (result.code === 0) {
+    const path = result.stdout.trim().split("\n")[0];
+    return path || null;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Current installed version
+// ---------------------------------------------------------------------------
+
+async function getCurrentVersion(claudeCommand) {
+  const cmd = claudeCommand || "claude";
+  const path = await resolveClaudePath(cmd);
+
+  if (!path) {
+    return { state: "not_installed", path: null };
+  }
+
+  const result = await runProcess(path, ["--version"]);
+
+  if (result.spawnError) {
+    // ENOENT case — binary moved between which() and exec()
+    return { state: "not_installed", path: path, error: result.spawnError };
+  }
+
+  if (result.code !== 0) {
+    // claude --version should not fail; treat as unknown so the UI surfaces it.
+    return {
+      state: "unknown",
+      path: path,
+      error: (result.stderr || result.stdout || "exit code " + result.code).trim(),
+    };
+  }
+
+  // Claude Code CLI version output formats observed:
+  //   "1.2.3 (Claude Code)"
+  //   "claude-code/1.2.3 (node)"
+  //   "1.2.3"
+  // Pattern: capture first X.Y.Z[-pre] anywhere on the first line.
+  const firstLine = (result.stdout || "").trim().split("\n")[0];
+  const match = firstLine.match(/(\d+\.\d+\.\d+(?:-[\w.]+)?)/);
+
+  if (!match) {
+    return { state: "unknown", path: path, raw: firstLine };
+  }
+
+  return { state: "installed", path: path, version: match[1], raw: firstLine };
+}
+
+// ---------------------------------------------------------------------------
+// Latest published version (npm registry)
+// ---------------------------------------------------------------------------
+
+function fetchWithTimeout(url, ms) {
+  return new Promise(function(resolve, reject) {
+    let settled = false;
+    const timer = setTimeout(function() {
+      if (!settled) {
+        settled = true;
+        reject(new Error("Request timed out after " + ms + "ms"));
+      }
+    }, ms);
+
+    fetch(url, {
+      headers: {
+        "Accept": "application/json",
+        "User-Agent": "claudecode-nova/" + (nova.extension.version || "0.0.0"),
+      },
+    }).then(function(response) {
+      if (settled) return;
+      clearTimeout(timer);
+      settled = true;
+      resolve(response);
+    }).catch(function(err) {
+      if (settled) return;
+      clearTimeout(timer);
+      settled = true;
+      reject(err);
+    });
+  });
+}
+
+async function getLatestVersion(channel) {
+  const ch = channel === "next" ? "next" : "stable";
+
+  let response;
+  try {
+    response = await fetchWithTimeout(NPM_REGISTRY_URL, FETCH_TIMEOUT_MS);
+  } catch (err) {
+    throw new Error("Could not reach npm registry: " + err.message);
+  }
+
+  if (!response.ok) {
+    throw new Error("npm registry returned HTTP " + response.status);
+  }
+
+  const data = await response.json();
+  const distTags = data["dist-tags"] || {};
+  const tag = ch === "next" ? "next" : "latest";
+  const version = distTags[tag];
+
+  if (!version) {
+    // Fallback to stable if next isn't published yet.
+    if (ch === "next" && distTags.latest) {
+      return { version: distTags.latest, channel: "stable", fellBack: true };
+    }
+    throw new Error("npm registry did not return a version for tag '" + tag + "'");
+  }
+
+  return { version: version, channel: ch, fellBack: false };
+}
+
+// ---------------------------------------------------------------------------
+// Install method detection
+// ---------------------------------------------------------------------------
+
+function detectInstallMethod(claudePath) {
+  if (!claudePath) return "unknown";
+  const p = claudePath;
+
+  if (p.indexOf("/.nvm/") !== -1) return "npm";
+  if (p.indexOf("/node_modules/") !== -1) return "npm";
+  if (p.indexOf("/lib/node_modules/") !== -1) return "npm";
+  if (p.indexOf("/Cellar/") !== -1) return "homebrew";
+  if (p.indexOf("/opt/homebrew/") !== -1) return "homebrew";
+  if (p.indexOf("/.local/") !== -1) return "standalone";
+  if (p.indexOf("/.claude/") !== -1) return "standalone";
+
+  return "unknown";
+}
+
+async function isNpmAvailable() {
+  const result = await runProcess("/usr/bin/which", ["npm"]);
+  return result.code === 0 && result.stdout.trim().length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Update execution
+// ---------------------------------------------------------------------------
+
+const UPDATE_COMMANDS = {
+  // `claude update` is the modern updater — prefer it everywhere it works.
+  "self":      { cmd: "claude",  args: ["update"] },
+  "npm":       { cmd: "npm",     args: ["update", "-g", "@anthropic-ai/claude-code"] },
+  "homebrew":  { cmd: "brew",    args: ["upgrade", "claude-code"] },
+  "standalone":{ cmd: "claude",  args: ["update"] },
+  "install-npm": { cmd: "npm",   args: ["install", "-g", "@anthropic-ai/claude-code"] },
+};
+
+// Try `claude update` first (works for the modern CLI regardless of install
+// method). On failure, fall back to the method-specific command.
+async function runUpdate(method, claudeCommand) {
+  const cmd = claudeCommand || "claude";
+  const claudePath = await resolveClaudePath(cmd);
+
+  // Attempt the integrated updater first when a claude binary is on the PATH.
+  if (claudePath) {
+    const selfRes = await runProcess(claudePath, ["update"]);
+    if (selfRes.code === 0) {
+      return {
+        success: true,
+        method: "self",
+        stdout: selfRes.stdout,
+        stderr: selfRes.stderr,
+      };
+    }
+    // Self-update can refuse with a non-zero code if the install method
+    // doesn't support it — fall through to package-manager-specific commands.
+  }
+
+  const fallback = UPDATE_COMMANDS[method];
+  if (!fallback || method === "unknown" || method === "self") {
+    return {
+      success: false,
+      method: method,
+      stdout: "",
+      stderr: claudePath
+        ? "`claude update` failed and no package-manager fallback is known for this install."
+        : "Claude Code CLI is not installed.",
+    };
+  }
+
+  const result = await runProcess("/usr/bin/env", [fallback.cmd].concat(fallback.args));
+  return {
+    success: result.code === 0,
+    method: method,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    code: result.code,
+  };
+}
+
+// Install Claude Code via npm. Separate entry point because UX-wise this is
+// distinct from "update an existing install" — the caller surfaces a
+// dedicated button only when isNpmAvailable() is true.
+async function installViaNpm() {
+  const spec = UPDATE_COMMANDS["install-npm"];
+  const result = await runProcess("/usr/bin/env", [spec.cmd].concat(spec.args));
+  return {
+    success: result.code === 0,
+    method: "install-npm",
+    stdout: result.stdout,
+    stderr: result.stderr,
+    code: result.code,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  parseSemver: parseSemver,
+  semverCompare: semverCompare,
+  getCurrentVersion: getCurrentVersion,
+  getLatestVersion: getLatestVersion,
+  resolveClaudePath: resolveClaudePath,
+  detectInstallMethod: detectInstallMethod,
+  isNpmAvailable: isNpmAvailable,
+  runUpdate: runUpdate,
+  installViaNpm: installViaNpm,
+};

--- a/claudecode-nova.novaextension/Scripts/version-tree-provider.js
+++ b/claudecode-nova.novaextension/Scripts/version-tree-provider.js
@@ -1,0 +1,111 @@
+/**
+ * version-tree-provider.js — single-item TreeDataProvider for the sidebar
+ * section that surfaces the current Claude Code CLI version + state.
+ *
+ * State shape (set by main.js, read by the provider):
+ *   {
+ *     state: "unknown" | "checking" | "installed" | "up_to_date" |
+ *            "update_available" | "not_installed" | "error",
+ *     currentVersion: string | null,
+ *     latestVersion: string | null,
+ *     channel: "stable" | "next",
+ *     lastCheckedAt: number | null,
+ *     message: string | null,
+ *   }
+ *
+ * The provider keeps a reference to the state; main.js mutates the same
+ * object and calls treeView.reload() to refresh the single row.
+ */
+
+class VersionTreeProvider {
+  constructor(state) {
+    this.state = state;
+  }
+
+  getChildren(element) {
+    if (!element) {
+      return [{ kind: "version" }];
+    }
+    return [];
+  }
+
+  getTreeItem(element) {
+    const s = this.state;
+    const item = new TreeItem(formatLabel(s));
+    item.identifier = "claudecode-version";
+    item.descriptiveText = formatDescriptive(s);
+    item.tooltip = formatTooltip(s);
+    item.image = pickImage(s);
+    item.command = "claudecode.checkForUpdates";
+    return item;
+  }
+}
+
+function formatLabel(s) {
+  switch (s.state) {
+    case "checking":
+      return "Checking for updates…";
+    case "up_to_date":
+      return "Claude Code " + s.currentVersion + " (up to date)";
+    case "update_available":
+      return "Claude Code " + s.currentVersion + " → " + s.latestVersion;
+    case "installed":
+      return "Claude Code " + (s.currentVersion || "?");
+    case "not_installed":
+      return "Claude Code: not installed";
+    case "error":
+      return "Claude Code: check failed";
+    case "unknown":
+    default:
+      return "Claude Code: version unknown";
+  }
+}
+
+function formatDescriptive(s) {
+  if (s.state === "update_available") return "Update available";
+  if (s.state === "up_to_date") return "Up to date";
+  if (s.state === "not_installed") return "Not found on PATH";
+  if (s.state === "checking") return "";
+  if (s.state === "error") return "Click to retry";
+  if (s.state === "installed" && s.lastCheckedAt) return "Last checked: " + relativeTime(s.lastCheckedAt);
+  return "";
+}
+
+function formatTooltip(s) {
+  const lines = [];
+  if (s.currentVersion) lines.push("Installed: " + s.currentVersion);
+  if (s.latestVersion) lines.push("Latest (" + (s.channel || "stable") + "): " + s.latestVersion);
+  if (s.lastCheckedAt) lines.push("Checked: " + new Date(s.lastCheckedAt).toLocaleString());
+  if (s.message) lines.push(s.message);
+  lines.push("Click to check for updates.");
+  return lines.join("\n");
+}
+
+function pickImage(s) {
+  switch (s.state) {
+    case "update_available":
+    case "not_installed":
+      return "__builtin.warning";
+    case "error":
+      return "__builtin.error";
+    case "up_to_date":
+    case "installed":
+      return "__builtin.info";
+    case "checking":
+      return "__builtin.refresh";
+    case "unknown":
+    default:
+      return "__builtin.info";
+  }
+}
+
+function relativeTime(ts) {
+  const diff = (Date.now() - ts) / 1000;
+  if (diff < 5) return "just now";
+  if (diff < 60) return Math.floor(diff) + "s ago";
+  if (diff < 3600) return Math.floor(diff / 60) + "m ago";
+  if (diff < 86400) return Math.floor(diff / 3600) + "h ago";
+  return new Date(ts).toLocaleDateString();
+}
+
+module.exports = { VersionTreeProvider: VersionTreeProvider };

--- a/claudecode-nova.novaextension/Scripts/ws-server.js
+++ b/claudecode-nova.novaextension/Scripts/ws-server.js
@@ -27,6 +27,16 @@ const PORT_MAX  = parseInt(process.env.CC_PORT_MAX  || "65535", 10);
 const WORKSPACE = process.env.CC_WORKSPACE || process.cwd();
 const IDE_NAME  = "Nova";
 
+// Chat UI (Mode B — opt-in chat panel in Nova Preview tab).
+// Enabled when CC_CHAT_ENABLED=1 is set by main.js at spawn time.
+// API key flows via ANTHROPIC_API_KEY (resolved from 1Password / Keychain
+// in main.js before spawning this subprocess).
+const CHAT_ENABLED = process.env.CC_CHAT_ENABLED === "1" || process.env.CC_CHAT_ENABLED === "true";
+const CHAT_PORT    = parseInt(process.env.CC_CHAT_PORT || "5180", 10);
+const CHAT_MODEL   = process.env.CC_CHAT_MODEL || "claude-sonnet-4-6";
+const CHAT_API_KEY = process.env.ANTHROPIC_API_KEY || "";
+let chatHandle = null;  // { port, stop() } once chat-session.mjs is initialized
+
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
@@ -420,32 +430,61 @@ process.stdin.on("data", (chunk) => {
   }
 });
 
+// Format a Nova tool result into the MCP `content` payload shape.
+// Pure function — used by both the MCP path and the chat path.
+function formatToolResultPayload(result) {
+  const isErr = result && typeof result === "object" && result.error;
+  const text = (typeof result === "string")
+    ? result
+    : JSON.stringify(isErr ? { error: result.error } : result);
+  const payload = { content: [{ type: "text", text }] };
+  if (isErr) payload.isError = true;
+  return payload;
+}
+
+// Chat-originated Nova tool call. Returns a Promise that resolves with the
+// MCP-shaped payload when main.js sends back the tool_result. Shares the
+// pendingRequests map with the MCP path via `kind: "chat"`.
+function callNovaTool(toolName, args) {
+  return new Promise((resolve, reject) => {
+    const requestId = `chat_req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const timeout = setTimeout(() => {
+      if (pendingRequests[requestId]) {
+        delete pendingRequests[requestId];
+        reject(new Error(`Nova tool ${toolName} timed out`));
+      }
+    }, 30000);
+    pendingRequests[requestId] = { kind: "chat", resolve, reject, timeout };
+    sendToNova({
+      type: "tool_call",
+      requestId,
+      tool: toolName,
+      arguments: args,
+    });
+  });
+}
+
 function handleNovaMessage(msg) {
-  // Tool result from Nova
+  // Tool result from Nova — dispatch by kind to the right resolver
   if (msg.type === "tool_result" && msg.requestId) {
     const pending = pendingRequests[msg.requestId];
     if (pending) {
       clearTimeout(pending.timeout);
       delete pendingRequests[msg.requestId];
 
-      // Spec output formats vary per tool: some return plain strings
-      // ("TAB_CLOSED", "Opened file: /path"), others return JSON-stringified
-      // objects. Preserve the handler's intent: a string result becomes the
-      // text verbatim, an object/array gets JSON-stringified, and an error
-      // surfaces via isError per MCP convention.
-      const r = msg.result;
-      const isErr = r && typeof r === "object" && r.error;
-      const text = (typeof r === "string")
-        ? r
-        : JSON.stringify(isErr ? { error: r.error } : r);
-      const payload = { content: [{ type: "text", text }] };
-      if (isErr) payload.isError = true;
+      const payload = formatToolResultPayload(msg.result);
 
-      sendWSMessage(pending.client, {
-        jsonrpc: "2.0",
-        id: pending.mcpId,
-        result: payload,
-      });
+      if (pending.kind === "chat") {
+        // Chat-originated — resolve the Promise the chat tool wrapper awaits
+        pending.resolve(payload);
+      } else {
+        // MCP-originated (default — backward compat) — send WS response
+        sendWSMessage(pending.client, {
+          jsonrpc: "2.0",
+          id: pending.mcpId,
+          result: payload,
+        });
+      }
     }
     return;
   }
@@ -633,7 +672,7 @@ async function startServer() {
     });
   });
 
-  httpServer.listen(port, "127.0.0.1", () => {
+  httpServer.listen(port, "127.0.0.1", async () => {
     lockFilePath = writeLockFile(port, authToken);
     log("info", `WebSocket MCP server listening on 127.0.0.1:${port}`);
     sendToNova({
@@ -642,6 +681,30 @@ async function startServer() {
       lockFile: lockFilePath,
       authToken,
     });
+
+    // Conditionally start the chat module (Mode B — opt-in chat UI).
+    // Wrapped in try/catch so a chat init failure never kills the MCP server.
+    if (CHAT_ENABLED) {
+      if (!CHAT_API_KEY) {
+        log("error", "Chat enabled (CC_CHAT_ENABLED=1) but ANTHROPIC_API_KEY missing — chat disabled");
+      } else {
+        try {
+          const chatModule = await import("./chat-session.mjs");
+          chatHandle = await chatModule.init({
+            port: CHAT_PORT,
+            apiKey: CHAT_API_KEY,
+            model: CHAT_MODEL,
+            callNovaTool,
+            log,
+          });
+          log("info", `Chat server listening on http://127.0.0.1:${CHAT_PORT}/`);
+          sendToNova({ type: "chat_started", port: CHAT_PORT });
+        } catch (err) {
+          log("error", `Failed to start chat server: ${err.message}`);
+          sendToNova({ type: "chat_failed", message: err.message });
+        }
+      }
+    }
   });
 
   // Cleanup on exit
@@ -649,6 +712,9 @@ async function startServer() {
     if (serverPort) removeLockFile(serverPort);
     for (const client of connectedClients) {
       try { client.socket.destroy(); } catch (_) {}
+    }
+    if (chatHandle) {
+      try { chatHandle.stop(); } catch (_) {}
     }
     process.exit(0);
   }

--- a/claudecode-nova.novaextension/extension.json
+++ b/claudecode-nova.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Claude Code Bridge",
   "organization": "okapi-ca",
   "description": "Integrates Claude Code CLI with Nova via the WebSocket MCP protocol, providing context sharing, diff viewing, and selection tracking.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "categories": ["commands", "sidebars"],
   "license": "MIT",
   "repository": "https://github.com/okapi-ca/claudecode-nova",
@@ -56,6 +56,14 @@
       {
         "title": "Launch Claude Code (with IDE integration)",
         "command": "claudecode.launchClaude"
+      },
+      {
+        "title": "Open Claude Chat in Browser",
+        "command": "claudecode.openChat"
+      },
+      {
+        "title": "Check for Claude Code Updates",
+        "command": "claudecode.checkForUpdates"
       }
     ]
   },
@@ -117,6 +125,32 @@
               "tooltip": "Clear activity log"
             }
           ]
+        },
+        {
+          "id": "claudecode.sidebar.version",
+          "name": "Claude Code Version",
+          "placeholderText": "Checking…",
+          "headerCommands": [
+            {
+              "title": "Check",
+              "image": "__builtin.refresh",
+              "command": "claudecode.checkForUpdates",
+              "tooltip": "Check for Claude Code updates"
+            }
+          ]
+        },
+        {
+          "id": "claudecode.sidebar.chat",
+          "name": "Chat UI",
+          "placeholderText": "Chat UI is disabled. Enable in settings.",
+          "headerCommands": [
+            {
+              "title": "Open",
+              "image": "__builtin.path.action",
+              "command": "claudecode.openChat",
+              "tooltip": "Open the Claude chat UI in your browser"
+            }
+          ]
         }
       ]
     }
@@ -173,6 +207,64 @@
       ],
       "default": "auto",
       "description": "Where the \"Launch Claude Code\" command opens the CLI. Other terminals (Warp, Ghostty, Hyper) fall back to clipboard — choose \"clipboard\" explicitly to keep the v0.1.x behaviour."
+    },
+    {
+      "key": "claudecode.updateCheck.autoCheck",
+      "title": "Auto-check for Claude Code updates",
+      "type": "boolean",
+      "default": true,
+      "description": "Check daily for new Claude Code CLI versions when the extension activates. Only shows a notification when an update is available."
+    },
+    {
+      "key": "claudecode.updateCheck.channel",
+      "title": "Update channel",
+      "type": "enum",
+      "values": [
+        ["stable", "Stable (npm latest)"],
+        ["next", "Next (npm @next pre-releases)"]
+      ],
+      "default": "stable",
+      "description": "Which npm dist-tag to compare against. \"next\" surfaces pre-release versions."
+    },
+    {
+      "key": "claudecode.chat.enabled",
+      "title": "Enable Chat UI (Mode B — experimental)",
+      "type": "boolean",
+      "default": false,
+      "description": "Opt-in to the in-browser chat UI powered by the Claude Agent SDK. Requires an Anthropic API key. When enabled, a chat server starts on the configured port; open the URL in Safari/Firefox or in Nova's Preview tab. Independent from the existing CLI bridge mode."
+    },
+    {
+      "key": "claudecode.chat.apiKey1PassRef",
+      "title": "Anthropic API Key — 1Password reference",
+      "type": "string",
+      "default": "",
+      "description": "1Password CLI reference like `op://Private/Anthropic API Key/credential`. Read at extension activation via `op read`. Leave empty if using the env var fallback or to disable chat auth."
+    },
+    {
+      "key": "claudecode.chat.apiKey",
+      "title": "Anthropic API Key — direct (fallback if 1Password not configured)",
+      "type": "string",
+      "default": "",
+      "description": "Direct API key — used only if the 1Password reference above is empty. Prefer the 1Password reference for security."
+    },
+    {
+      "key": "claudecode.chat.model",
+      "title": "Chat model",
+      "type": "enum",
+      "values": [
+        ["claude-sonnet-4-6", "Sonnet 4.6 (recommended — cheap, capable)"],
+        ["claude-haiku-4-5", "Haiku 4.5 (fastest, lowest cost)"],
+        ["claude-opus-4-7", "Opus 4.7 (most capable, expensive)"]
+      ],
+      "default": "claude-sonnet-4-6",
+      "description": "Model used by the chat UI. Sonnet 4.6 hits the sweet spot for cost/quality."
+    },
+    {
+      "key": "claudecode.chat.port",
+      "title": "Chat UI port",
+      "type": "number",
+      "default": 5180,
+      "description": "Fixed port for the chat HTTP server. Configure Nova's Project Settings → Preview URL to http://127.0.0.1:<port>/ to use the chat UI inside the Preview tab."
     }
   ],
 

--- a/claudecode-nova.novaextension/main.js
+++ b/claudecode-nova.novaextension/main.js
@@ -7,7 +7,13 @@
  *   3. Maps MCP tool calls to Nova editor APIs
  *   4. Tracks editor selection and broadcasts changes
  *   5. Provides sidebar UI and commands
+ *   6. Checks the Claude Code CLI for updates (manual + 24h auto)
  */
+
+const UpdateCheck = require("./Scripts/update-check.js");
+const { VersionTreeProvider } = require("./Scripts/version-tree-provider.js");
+
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h auto-check throttle
 
 // ---------------------------------------------------------------------------
 // State
@@ -42,6 +48,21 @@ let gitBranch = null;
 let gitBranchTimer = null;
 const GIT_BRANCH_REFRESH_MS = 5 * 60 * 1000;
 
+// Claude Code CLI version state. Mutated by checkForUpdates() and read by
+// the sidebar provider — same object reference passed both ways so the
+// provider always reflects the latest snapshot after a reload().
+let versionState = {
+  state: "unknown",
+  currentVersion: null,
+  latestVersion: null,
+  channel: "stable",
+  lastCheckedAt: null,
+  message: null,
+};
+let versionProvider = null;
+let versionTree = null;
+let updateInProgress = false;
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -64,6 +85,8 @@ exports.activate = function() {
       nova.commands.register("claudecode.diffReject", diffRejectHandler),
       nova.commands.register("claudecode.diffShowDetails", diffShowDetailsHandler),
       nova.commands.register("claudecode.sidebarRefresh", sidebarRefreshHandler),
+      nova.commands.register("claudecode.checkForUpdates", function() { checkForUpdates(false); }),
+      nova.commands.register("claudecode.openChat", openChatHandler),
     );
     console.log("Claude Code Bridge: commands registered");
   } catch (err) {
@@ -83,13 +106,16 @@ exports.activate = function() {
 
   const autoStart = nova.config.get("claudecode.autoStart");
   if (autoStart !== false) {
-    try {
-      startBridge();
-    } catch (err) {
+    // Chat key resolution may need an `op read` round-trip, so startBridge is
+    // now async. Fire-and-forget — no caller awaits the return.
+    startBridge().catch((err) => {
       console.error("Claude Code Bridge: startBridge() failed:", err.message, err.stack || "");
       showNotification("Error", `Failed to start bridge: ${err.message}`);
-    }
+    });
   }
+
+  // Fire-and-forget: never block activate() on a network round-trip.
+  maybeAutoCheckUpdates();
 
   console.log("Claude Code Bridge: activation complete");
 };
@@ -139,10 +165,96 @@ function resolveNodePath() {
 }
 
 // ---------------------------------------------------------------------------
+// Chat (Mode B) — opt-in chat UI helpers
+// ---------------------------------------------------------------------------
+
+// Resolve the Anthropic API key for chat mode. Tries 1Password CLI first
+// (via `op read <ref>`), falls back to the direct config value. Returns
+// the key string, or empty string if no source is configured / op fails.
+async function resolveChatApiKey() {
+  const opRef  = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
+  const direct = (nova.config.get("claudecode.chat.apiKey") || "").trim();
+
+  if (opRef) {
+    try {
+      const key = await runOpRead(opRef);
+      if (key) return key;
+    } catch (err) {
+      console.warn("Claude Code Bridge: op read failed (" + err.message + ") — falling back to direct key");
+    }
+  }
+
+  return direct;
+}
+
+// Run `op read <ref>` and capture stdout. Resolves with the trimmed output
+// on exit 0, rejects on non-zero exit or spawn failure.
+function runOpRead(ref) {
+  return new Promise((resolve, reject) => {
+    const proc = new Process("/usr/bin/env", {
+      args: ["op", "read", ref],
+      shell: false,
+      stdio: "pipe",
+    });
+    let out = "";
+    let err = "";
+    proc.onStdout(function(chunk) { out += chunk; });
+    proc.onStderr(function(chunk) { err += chunk; });
+    proc.onDidExit(function(code) {
+      if (code === 0) resolve(out.trim());
+      else reject(new Error("op exit code " + code + ": " + err.trim()));
+    });
+    try {
+      proc.start();
+    } catch (spawnErr) {
+      reject(new Error("Cannot spawn op CLI: " + spawnErr.message));
+    }
+  });
+}
+
+// "Open Claude Chat in Browser" command — shows the chat URL with copy and
+// browser-open actions. Guides the user to configure Nova Project Settings
+// (Preview URL) so the chat can live inside Nova's Preview tab.
+function openChatHandler() {
+  if (!nova.config.get("claudecode.chat.enabled")) {
+    nova.workspace.showActionPanel(
+      "Chat UI is currently disabled.",
+      { buttons: ["Open Settings", "Cancel"] },
+      function(idx) {
+        if (idx === 0) nova.openConfig(nova.extension.identifier);
+      },
+    );
+    return;
+  }
+
+  const port = nova.config.get("claudecode.chat.port") || 5180;
+  const url  = "http://127.0.0.1:" + port + "/";
+
+  nova.workspace.showActionPanel(
+    "Claude Chat UI\n\n" + url + "\n\nTo use inside Nova's Preview tab, configure\nProject Settings → Web → Preview URL to the URL above.",
+    { buttons: ["Copy URL", "Open in Browser", "Close"] },
+    function(idx) {
+      if (idx === 0) {
+        nova.clipboard.writeText(url);
+        showNotification("Copied", url + " is in your clipboard.");
+      } else if (idx === 1) {
+        // Best-effort: spawn `open <url>` (macOS) to launch the default browser.
+        try {
+          const proc = new Process("/usr/bin/open", { args: [url], stdio: "ignore" });
+          proc.start();
+        } catch (err) {
+          showNotification("Cannot open browser", err.message);
+        }
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Bridge lifecycle
 // ---------------------------------------------------------------------------
 
-function startBridge() {
+async function startBridge() {
   if (serverProcess) {
     console.log("Claude Code Bridge: already running");
     showNotification("Already Running", "Claude Code Bridge is already active.");
@@ -161,14 +273,40 @@ function startBridge() {
   console.log("  Script: " + scriptPath);
   console.log("  Workspace: " + workspace);
 
+  // Build env. If chat (Mode B) is opt-in, resolve the API key first
+  // (1Password reference or direct config value) and add the CC_CHAT_* vars
+  // so ws-server.js lazy-loads chat-session.mjs at startup.
+  const env = {
+    CC_PORT_MIN: String(portMin),
+    CC_PORT_MAX: String(portMax),
+    CC_WORKSPACE: workspace,
+  };
+
+  if (nova.config.get("claudecode.chat.enabled")) {
+    try {
+      const apiKey = await resolveChatApiKey();
+      if (apiKey) {
+        env.CC_CHAT_ENABLED = "1";
+        env.CC_CHAT_PORT    = String(nova.config.get("claudecode.chat.port") || 5180);
+        env.CC_CHAT_MODEL   = nova.config.get("claudecode.chat.model") || "claude-sonnet-4-6";
+        env.ANTHROPIC_API_KEY = apiKey;
+        console.log("Claude Code Bridge: chat enabled, port " + env.CC_CHAT_PORT + ", model " + env.CC_CHAT_MODEL);
+      } else {
+        console.warn("Claude Code Bridge: chat enabled but no API key resolved — chat will be disabled");
+        showNotification(
+          "Chat key missing",
+          "Chat UI is enabled but no Anthropic API key was found.\nConfigure 'Anthropic API Key — 1Password reference' or the direct key in Extension Settings."
+        );
+      }
+    } catch (err) {
+      console.error("Claude Code Bridge: chat API key resolution failed:", err.message);
+    }
+  }
+
   try {
     serverProcess = new Process(nodePath, {
       args: [scriptPath],
-      env: {
-        CC_PORT_MIN: String(portMin),
-        CC_PORT_MAX: String(portMax),
-        CC_WORKSPACE: workspace,
-      },
+      env,
       cwd: workspace || undefined,
       stdio: "pipe",
     });
@@ -320,6 +458,19 @@ function handleServerMessage(msg) {
       } else {
         console.log("[ws-server] " + msg.message);
       }
+      break;
+
+    case "chat_started":
+      console.log("Claude Code Bridge: chat server started on port " + msg.port);
+      showNotification(
+        "Chat UI ready",
+        "Claude chat is live at http://127.0.0.1:" + msg.port + "/.\nUse \"Open Claude Chat in Browser\" command to open it, or configure Nova Project Settings → Preview URL."
+      );
+      break;
+
+    case "chat_failed":
+      console.error("Claude Code Bridge: chat server failed — " + msg.message);
+      showNotification("Chat UI failed to start", msg.message);
       break;
   }
 }
@@ -1035,9 +1186,21 @@ function ensureActivitySidebars() {
       });
       disposables.push(activityTree);
     }
+    if (!versionProvider) {
+      versionProvider = new VersionTreeProvider(versionState);
+      versionTree = new TreeView("claudecode.sidebar.version", {
+        dataProvider: versionProvider,
+      });
+      disposables.push(versionTree);
+    }
   } catch (err) {
     console.error("Claude Code Bridge: activity sidebar init failed:", err.message);
   }
+}
+
+function refreshVersionSidebar() {
+  ensureActivitySidebars();
+  try { if (versionTree) versionTree.reload(); } catch (_) {}
 }
 
 // Reload both activity-related sections. Called after every event that
@@ -1624,6 +1787,286 @@ function runAppleScript(script) {
       reject(err);
     }
   });
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code CLI version check & update
+// ---------------------------------------------------------------------------
+//
+// Three entry points feed the same pipeline:
+//   1. activate() → maybeAutoCheckUpdates() — silent, throttled to 24h.
+//   2. Command "Claude Code: Check for Updates" → checkForUpdates(false).
+//   3. Sidebar click on the version row → checkForUpdates(false).
+//
+// `silent=true` suppresses all notifications EXCEPT the "update available"
+// one — that's the whole point of the daily auto-check.
+
+function maybeAutoCheckUpdates() {
+  if (nova.config.get("claudecode.updateCheck.autoCheck") === false) return;
+  const last = nova.config.get("claudecode.updateCheck.lastCheckedAt") || 0;
+  if (Date.now() - last < UPDATE_CHECK_INTERVAL_MS) return;
+  checkForUpdates(true).catch(function(err) {
+    console.warn("Claude Code Bridge: auto-check failed:", err.message);
+  });
+}
+
+async function checkForUpdates(silent) {
+  const claudeCommand = nova.workspace.config.get("claudecode.claudeCommand") || "claude";
+  const channel = nova.config.get("claudecode.updateCheck.channel") || "stable";
+  versionState.channel = channel;
+
+  if (!silent) {
+    versionState.state = "checking";
+    versionState.message = null;
+    refreshVersionSidebar();
+  }
+
+  let current;
+  try {
+    current = await UpdateCheck.getCurrentVersion(claudeCommand);
+  } catch (err) {
+    console.error("Claude Code Bridge: getCurrentVersion failed:", err.message);
+    versionState.state = "error";
+    versionState.message = err.message;
+    refreshVersionSidebar();
+    if (!silent) showNotification("Update Check Failed", err.message);
+    persistLastChecked();
+    return;
+  }
+
+  if (current.state === "not_installed") {
+    versionState.state = "not_installed";
+    versionState.currentVersion = null;
+    versionState.message = "Claude Code CLI was not found on PATH.";
+    refreshVersionSidebar();
+    presentNotInstalled(silent);
+    persistLastChecked();
+    return;
+  }
+
+  if (current.state === "unknown") {
+    versionState.state = "unknown";
+    versionState.currentVersion = null;
+    versionState.message = current.error || current.raw || "Unparsable version output.";
+    refreshVersionSidebar();
+    if (!silent) {
+      showNotification("Version Unknown",
+        "Could not parse `claude --version` output: " + versionState.message);
+    }
+    persistLastChecked();
+    return;
+  }
+
+  versionState.currentVersion = current.version;
+
+  let latest;
+  try {
+    latest = await UpdateCheck.getLatestVersion(channel);
+  } catch (err) {
+    versionState.state = "error";
+    versionState.message = err.message;
+    refreshVersionSidebar();
+    if (!silent) showNotification("Update Check Failed", err.message);
+    persistLastChecked();
+    return;
+  }
+
+  versionState.latestVersion = latest.version;
+  const cmp = UpdateCheck.semverCompare(current.version, latest.version);
+  persistLastChecked();
+
+  if (cmp === null) {
+    versionState.state = "unknown";
+    versionState.message = "Could not compare versions (" + current.version + " vs " + latest.version + ").";
+    refreshVersionSidebar();
+    return;
+  }
+
+  if (cmp >= 0) {
+    versionState.state = "up_to_date";
+    versionState.message = null;
+    refreshVersionSidebar();
+    if (!silent) {
+      showNotification("Up to Date", "Claude Code is up to date (v" + current.version + ").");
+    }
+    return;
+  }
+
+  // Update available — always notify, even on silent auto-check.
+  versionState.state = "update_available";
+  versionState.message = "Update available: v" + current.version + " → v" + latest.version;
+  refreshVersionSidebar();
+  presentUpdateAvailable(current, latest);
+}
+
+function presentUpdateAvailable(current, latest) {
+  const req = new NotificationRequest("claudecode-update-available");
+  req.title = "Claude Code Update Available";
+  req.body = "v" + current.version + " → v" + latest.version + ".\nUpdate will stop and restart the bridge.";
+  req.actions = ["Update Now", "Release Notes", "Later"];
+
+  nova.notifications.add(req).then(function(response) {
+    if (response.actionIdx === 0) {
+      const method = UpdateCheck.detectInstallMethod(current.path);
+      runUpdateFlow(method);
+    } else if (response.actionIdx === 1) {
+      const url = "https://github.com/anthropics/claude-code/releases/tag/v" + latest.version;
+      try { nova.openURL(url); }
+      catch (err) {
+        nova.clipboard.writeText(url);
+        showNotification("Release Notes", "URL copied to clipboard: " + url);
+      }
+    }
+    // "Later" → no-op; user can re-check via the sidebar or command.
+  });
+}
+
+async function presentNotInstalled(silent) {
+  if (silent && nova.config.get("claudecode.updateCheck.suppressNotInstalled") === true) {
+    return;
+  }
+
+  const npmOk = !silent && (await UpdateCheck.isNpmAvailable());
+
+  const req = new NotificationRequest("claudecode-not-installed");
+  req.title = "Claude Code CLI Not Found";
+  req.body = "The Claude Code CLI is not on PATH. The bridge runs without it, but you'll need it to launch Claude from Nova.";
+  req.actions = ["Install Guide", "Configure Path"];
+  if (npmOk) req.actions.push("Install via npm");
+  if (silent) req.actions.push("Don't Show Again");
+
+  nova.notifications.add(req).then(function(response) {
+    const action = req.actions[response.actionIdx];
+    if (action === "Install Guide") {
+      const url = "https://docs.anthropic.com/claude-code/install";
+      try { nova.openURL(url); }
+      catch (_) {
+        nova.clipboard.writeText(url);
+        showNotification("Install Guide", "URL copied to clipboard: " + url);
+      }
+    } else if (action === "Configure Path") {
+      try { nova.workspace.openConfig(nova.extension.identifier); }
+      catch (err) {
+        showNotification("Open Settings", "Could not open extension settings: " + err.message);
+      }
+    } else if (action === "Install via npm") {
+      runInstallFlow();
+    } else if (action === "Don't Show Again") {
+      nova.config.set("claudecode.updateCheck.suppressNotInstalled", true);
+    }
+  });
+}
+
+async function runUpdateFlow(method) {
+  if (updateInProgress) {
+    showNotification("Update In Progress", "An update is already running.");
+    return;
+  }
+  updateInProgress = true;
+
+  const wasRunning = !!serverProcess;
+  if (wasRunning) {
+    stopBridge();
+    await delay(500); // give the OS a moment to release the port
+  }
+
+  showNotification("Updating", "Updating Claude Code… the bridge will restart automatically.");
+  const claudeCommand = nova.workspace.config.get("claudecode.claudeCommand") || "claude";
+
+  let result;
+  try {
+    result = await UpdateCheck.runUpdate(method, claudeCommand);
+  } catch (err) {
+    console.error("Claude Code Bridge: update threw:", err.message);
+    result = { success: false, stderr: err.message };
+  }
+
+  updateInProgress = false;
+
+  if (result.success) {
+    // Re-probe the new version so the sidebar reflects reality.
+    try {
+      const current = await UpdateCheck.getCurrentVersion(claudeCommand);
+      if (current.state === "installed") {
+        versionState.currentVersion = current.version;
+        versionState.state = "up_to_date";
+        versionState.message = null;
+        refreshVersionSidebar();
+      }
+    } catch (_) {}
+
+    showNotification("Update Complete",
+      "Claude Code updated successfully" +
+      (versionState.currentVersion ? " to v" + versionState.currentVersion : "") + ".");
+
+    if (wasRunning) {
+      setTimeout(function() {
+        try { startBridge(); } catch (err) {
+          console.error("Claude Code Bridge: post-update restart failed:", err.message);
+          showNotification("Restart Failed", "Update succeeded but bridge restart failed: " + err.message);
+        }
+      }, 300);
+    }
+  } else {
+    // Don't auto-restart the bridge on failure — leave the user in a stable
+    // state so they can diagnose. The previous claude is still installed.
+    const stderr = (result.stderr || "").trim();
+    const req = new NotificationRequest("claudecode-update-failed");
+    req.title = "Claude Code Update Failed";
+    req.body = stderr ? stderr.slice(0, 500) : "Update command returned a non-zero exit code.";
+    req.actions = ["Copy Log", "OK"];
+    nova.notifications.add(req).then(function(response) {
+      if (response.actionIdx === 0) {
+        const full = "stdout:\n" + (result.stdout || "") + "\n\nstderr:\n" + (result.stderr || "");
+        nova.clipboard.writeText(full);
+      }
+    });
+  }
+}
+
+async function runInstallFlow() {
+  if (updateInProgress) {
+    showNotification("Install In Progress", "An install is already running.");
+    return;
+  }
+  updateInProgress = true;
+  showNotification("Installing", "Installing @anthropic-ai/claude-code globally via npm…");
+
+  let result;
+  try {
+    result = await UpdateCheck.installViaNpm();
+  } catch (err) {
+    result = { success: false, stderr: err.message };
+  }
+  updateInProgress = false;
+
+  if (result.success) {
+    showNotification("Install Complete", "Claude Code installed. Run \"Check for Updates\" to refresh the sidebar.");
+    // Trigger a re-check so the sidebar updates without user action.
+    checkForUpdates(true).catch(function(_) {});
+  } else {
+    const req = new NotificationRequest("claudecode-install-failed");
+    req.title = "Install Failed";
+    req.body = (result.stderr || "npm install exited with a non-zero code.").slice(0, 500);
+    req.actions = ["Copy Log", "OK"];
+    nova.notifications.add(req).then(function(response) {
+      if (response.actionIdx === 0) {
+        nova.clipboard.writeText("stdout:\n" + (result.stdout || "") + "\n\nstderr:\n" + (result.stderr || ""));
+      }
+    });
+  }
+}
+
+function persistLastChecked() {
+  try {
+    nova.config.set("claudecode.updateCheck.lastCheckedAt", Date.now());
+    if (versionState.currentVersion) {
+      nova.config.set("claudecode.updateCheck.lastSeenVersion", versionState.currentVersion);
+    }
+  } catch (err) {
+    console.warn("Claude Code Bridge: could not persist lastCheckedAt:", err.message);
+  }
+  versionState.lastCheckedAt = Date.now();
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/specs/claude-code-update-check.md
+++ b/docs/specs/claude-code-update-check.md
@@ -1,0 +1,275 @@
+# Spec — Vérification & mise à jour de Claude Code CLI
+
+**Statut** : Draft
+**Auteur** : Marc Bourget
+**Date** : 2026-05-27
+**Cible** : claudecode-nova v0.6.0
+
+---
+
+## 1. Contexte
+
+L'extension `claudecode-nova` lance le subprocess `claude` (CLI Anthropic) via la commande `claudecode.launchClaude` et communique avec lui via WebSocket MCP. Aujourd'hui, l'utilisateur doit :
+
+- vérifier manuellement sa version (`claude --version` dans un terminal),
+- comparer à la dernière version publiée (npm / GitHub releases),
+- exécuter la mise à jour (`claude update` ou `npm update -g @anthropic-ai/claude-code` selon la méthode d'install).
+
+C'est friction inutile, et la dérive de version peut causer des incompatibilités silencieuses avec le protocole MCP (`2024-11-05` actuellement) ou avec les schémas d'outils alignés sur PROTOCOL.md (cf. v0.5.0).
+
+## 2. Objectif
+
+Permettre à l'utilisateur de **vérifier et mettre à jour Claude Code CLI sans quitter Nova**, avec un signal proactif et discret quand une nouvelle version est disponible.
+
+## 3. Scope
+
+### Inclus
+
+- Commande explicite `Claude Code: Check for Updates` (menu Extensions + Command Palette).
+- Check automatique léger au démarrage de l'extension, throttlé à **1× par 24 h** (timestamp persisté dans `nova.config`).
+- Notification non-bloquante (`NotificationRequest`) quand une mise à jour est détectée, avec bouton `Update Now`.
+- Exécution de la mise à jour avec arrêt propre du ws-server, update, redémarrage automatique, reconnexion.
+- Setting pour désactiver le check automatique.
+
+### Exclus
+
+- Pas d'auto-update silencieuse (toujours opt-in via clic utilisateur).
+- Pas de gestion multi-versions / version pinning (laisser au CLI).
+- Pas de rollback automatique en cas d'échec d'update.
+- Pas de support des installations gérées par un package manager d'OS exotique (Nix, Snap) — détection best-effort.
+
+## 4. Solution
+
+### 4.1 Détection de la version courante
+
+Exécuter `<claudeCommand> --version` via l'API `Process` (réutilise `claudecode.claudeCommand` du workspace config). Output attendu : `claude-code/X.Y.Z (node)`. Parser avec `/^claude-code\/(\d+\.\d+\.\d+)(?:-([\w.]+))?/` pour capturer aussi les pre-releases (`X.Y.Z-beta.1`).
+
+États possibles retournés par `getCurrentVersion()` :
+
+| État | Condition | Trigger |
+|---|---|---|
+| `installed` | Process exit 0 + output parsable | version capturée, comparaison enclenchée |
+| `not_installed` | Process échoue avec ENOENT / "command not found" | UX dédiée (§4.7) |
+| `unknown` | Process exit 0 mais output non parsable, ou exit ≠ 0 avec stderr exploitable | log + notif diagnostique |
+
+### 4.2 Détection de la dernière version publiée
+
+Source primaire : **npm registry** via `fetch("https://registry.npmjs.org/@anthropic-ai/claude-code/latest")`. Réponse JSON : extraire `.version`. C'est rapide (~150 ms), public, pas d'auth, déjà couvert par l'entitlement `requests`.
+
+Fallback : GitHub releases (`https://api.github.com/repos/anthropics/claude-code/releases/latest`) — utile si npm est down ou si Anthropic publie hors-npm dans le futur.
+
+### 4.3 Détection de la méthode d'install
+
+Heuristique sur le chemin résolu de `claude` :
+
+| Chemin matché | Méthode | Commande update |
+|---|---|---|
+| `~/.nvm/`, `/usr/local/lib/node_modules`, `*/node_modules/.bin/` | npm global | `npm update -g @anthropic-ai/claude-code` |
+| `/opt/homebrew/`, `/usr/local/Cellar/` | Homebrew | `brew upgrade claude-code` |
+| `~/.local/`, `~/.claude/`, `/usr/local/bin/claude` (standalone) | Installer standalone | `claude update` (updater intégré) |
+| _autre_ | unknown | proposer `claude update` puis fallback message « update manually » |
+
+Résoudre le chemin avec `which <claudeCommand>` (via Process + shell). Si `claude update` retourne un code de succès, l'utiliser en priorité quelle que soit la méthode — c'est ce que la CLI moderne supporte nativement.
+
+### 4.4 Flow utilisateur
+
+#### Vérification manuelle (`Claude Code: Check for Updates`)
+
+```
+1. Utilisateur invoque la commande.
+2. Extension affiche "Checking…" via NotificationRequest (id stable, écrasable).
+3. Parallèle : version courante (Process) + version distante (fetch).
+4. Comparaison semver.
+5. Trois cas :
+   a. à jour     → NotificationRequest "Claude Code is up to date (vX.Y.Z)" + bouton OK.
+   b. obsolète   → NotificationRequest "Update available: vA.B.C → vX.Y.Z" + boutons [Update Now] [Later] [Release Notes].
+   c. introuvable → NotificationRequest "Claude Code CLI not found at '<path>'" + bouton [Open Settings].
+```
+
+#### Check automatique au startup
+
+```
+1. activate() lit `claudecode.updateCheck.lastCheckedAt` depuis nova.config.
+2. Si > 24h ou jamais → check silencieux en background (Promise non bloquante).
+3. Si update disponible → NotificationRequest cas (b) ci-dessus.
+4. Si à jour ou erreur → écrit le timestamp, n'affiche rien.
+5. Si setting `claudecode.updateCheck.autoCheck` est false → skip.
+```
+
+#### Exécution de l'update
+
+```
+1. NotificationRequest "Updating Claude Code… The bridge will restart automatically."
+2. Si ws-server tourne :
+   a. Envoyer un signal d'arrêt propre (claudecode.stop interne).
+   b. Attendre exit code ou timeout 5s puis SIGTERM.
+3. Lancer `<updateCommand>` via Process, capturer stdout/stderr.
+4. À l'exit :
+   - code 0 → re-vérifier la version, NotificationRequest "Updated to vX.Y.Z" + auto-redémarrer ws-server.
+   - code ≠ 0 → NotificationRequest erreur avec stderr tronqué + bouton [Copy Log] + ne PAS redémarrer ws-server (laisser l'utilisateur diagnostiquer).
+5. Mettre à jour `lastCheckedAt`.
+```
+
+### 4.5 Cas « Claude Code n'est pas installé »
+
+L'extension fonctionne sans `claude` jusqu'à ce que l'utilisateur invoque `claudecode.launchClaude` — le ws-server tourne en autonomie sur Node. Le check de version sert justement à exposer ce gap proactivement.
+
+#### Détection
+
+`getCurrentVersion()` retourne `not_installed` quand :
+- `Process` lance avec ENOENT (binaire absent du PATH),
+- `which <claudeCommand>` ne renvoie rien,
+- ou stderr contient `command not found` / `not recognized`.
+
+#### Comportement au démarrage (auto-check)
+
+- Notification one-shot : *« Claude Code CLI not found. Install it to use the bridge. »*
+- Boutons : `[Install Guide]` (ouvre `https://docs.anthropic.com/claude-code/install` via `nova.openURL`) — `[Configure Path]` (ouvre les workspace settings sur la clé `claudecode.claudeCommand`) — `[Don't Show Again]` (set `claudecode.updateCheck.suppressNotInstalled = true`).
+- `lastCheckedAt` est tout de même mis à jour pour respecter le throttling 24h.
+- Le ws-server démarre normalement — l'absence de `claude` ne bloque rien d'autre.
+
+#### Comportement sur invocation manuelle de `Check for Updates`
+
+- Affiche la notification ci-dessus **sans** suppression (l'utilisateur a explicitement demandé).
+- Ajoute un 4e bouton `[Install via npm]` qui lance `npm install -g @anthropic-ai/claude-code` via Process **uniquement** si npm est détecté sur le PATH (via `which npm`). Sinon le bouton n'apparaît pas — éviter de proposer une commande qui va échouer.
+
+#### Comportement sur invocation de `Launch Claude Code`
+
+Hors scope de cette spec (existe déjà), mais devrait à terme appeler `getCurrentVersion()` en pré-flight et afficher la même notification si `not_installed` — éviter un terminal qui ouvre sur un `command not found`. À documenter comme follow-up.
+
+#### Sidebar
+
+L'item version affiche : *« Claude Code: not installed »* en couleur d'alerte (via `image: "__builtin.warning"`). Clic invoque `claudecode.checkForUpdates` qui présente les boutons d'action.
+
+### 4.6 Configuration ajoutée
+
+Dans `extension.json` → `"config"` :
+
+```json
+{
+  "key": "claudecode.updateCheck.autoCheck",
+  "title": "Auto-check for Claude Code updates",
+  "type": "boolean",
+  "default": true,
+  "description": "Check daily for new Claude Code CLI versions at extension startup. Only shows a notification when an update is available."
+},
+{
+  "key": "claudecode.updateCheck.channel",
+  "title": "Update channel",
+  "type": "enum",
+  "values": [
+    ["stable", "Stable (npm latest)"],
+    ["next", "Next (npm @next pre-releases)"]
+  ],
+  "default": "stable"
+}
+```
+
+État interne (pas exposé dans UI, écrit via `nova.config.set`) :
+
+- `claudecode.updateCheck.lastCheckedAt` (number, epoch ms)
+- `claudecode.updateCheck.lastSeenVersion` (string)
+- `claudecode.updateCheck.suppressNotInstalled` (boolean) — set par le bouton `[Don't Show Again]` de la notif « not installed »
+
+### 4.7 Commandes ajoutées
+
+Dans `extension.json` → `"commands"."extensions"` :
+
+```json
+{ "title": "Check for Claude Code Updates", "command": "claudecode.checkForUpdates" }
+```
+
+Pas de raccourci clavier par défaut — découverte via menu Extensions / Command Palette.
+
+## 5. Détails d'implémentation
+
+### Modules touchés
+
+| Fichier | Modification |
+|---|---|
+| `claudecode-nova.novaextension/extension.json` | Ajouter 1 commande + 2 settings UI + 3 settings internes + 1 section sidebar |
+| `claudecode-nova.novaextension/main.js` | Enregistrer `claudecode.checkForUpdates`, démarrer auto-check dans `activate()`, monter `VersionTreeProvider` pour la nouvelle section sidebar |
+| `claudecode-nova.novaextension/Scripts/update-check.js` _(nouveau)_ | Module dédié avec `getCurrentVersion()`, `getLatestVersion()`, `detectInstallMethod()`, `runUpdate()`, sémaphore semver |
+| `claudecode-nova.novaextension/Scripts/version-tree-provider.js` _(nouveau)_ | `TreeDataProvider` pour la section sidebar « Claude Code » (single-item, état dynamique) |
+
+`update-check.js` tourne dans JavaScriptCore (pas Node) — utiliser `fetch()`, `Process`, pas de modules npm. Bundling déjà nécessaire si on veut `semver` ; sinon implémenter un comparateur semver minimal (~20 lignes) inline.
+
+### Comparaison semver minimal
+
+Nécessite le support pre-release dès v1 puisque le canal `next` est offert (Q1).
+
+```javascript
+function parseSemver(v) {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-([\w.]+))?$/);
+  if (!m) return null;
+  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] || null };
+}
+
+function semverCompare(a, b) {
+  const pa = parseSemver(a), pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  const core = (pa.major - pb.major) || (pa.minor - pb.minor) || (pa.patch - pb.patch);
+  if (core !== 0) return core;
+  if (pa.pre === pb.pre) return 0;
+  if (pa.pre === null) return 1;   // X.Y.Z > X.Y.Z-anything
+  if (pb.pre === null) return -1;
+  return pa.pre < pb.pre ? -1 : 1; // ordre lexico des pre-tags — suffisant pour `beta.N`, `rc.N`
+}
+```
+
+~30 lignes, pas de dépendance, couvre les cas Anthropic actuels.
+
+### Gestion des erreurs réseau
+
+- Timeout `fetch` : 5 secondes via `AbortController`.
+- Échec → log console, pas de notification (le check automatique reste silencieux par design).
+- Le check manuel affiche une erreur explicite « Could not reach npm registry ».
+
+## 6. Acceptance criteria
+
+- [ ] La commande `Claude Code: Check for Updates` apparaît dans le menu Extensions et la Command Palette.
+- [ ] Invoquer la commande quand Claude Code est à jour affiche une notification de confirmation avec la version.
+- [ ] Invoquer la commande quand une mise à jour est disponible affiche une notification avec 3 boutons (Update Now, Later, Release Notes).
+- [ ] Cliquer `Release Notes` ouvre `https://github.com/anthropics/claude-code/releases/tag/v<latest>` via `nova.openURL`.
+- [ ] Cliquer `Update Now` arrête le ws-server, exécute l'update, redémarre le ws-server, affiche le succès.
+- [ ] Une erreur d'update n'arrête pas le ws-server (état stable conservé).
+- [ ] Au démarrage de l'extension, le check auto fire **une seule fois par 24h** (vérifiable via les timestamps).
+- [ ] Désactiver `claudecode.updateCheck.autoCheck` supprime le check au démarrage.
+- [ ] Le check auto échoue silencieusement si le réseau est indisponible (pas de notification d'erreur intempestive).
+- [ ] Si `claudecode.claudeCommand` pointe vers un binaire inexistant, la notification d'erreur dirige vers les settings.
+- [ ] Quand Claude Code n'est pas installé, la notification au démarrage propose `[Install Guide]`, `[Configure Path]`, `[Don't Show Again]`.
+- [ ] Le bouton `[Don't Show Again]` set `suppressNotInstalled = true` ; la prochaine notif auto-startup ne s'affiche plus tant qu'un check manuel n'a pas réinitialisé l'état.
+- [ ] Sur invocation manuelle de `Check for Updates` sans claude installé, un bouton `[Install via npm]` apparaît **uniquement** si `npm` est sur le PATH.
+- [ ] La section sidebar « Claude Code » apparaît avec la version courante et un état visuel (à jour / update dispo / not installed / unknown).
+- [ ] Cliquer sur l'item sidebar invoque `claudecode.checkForUpdates`.
+- [ ] Le canal `next` interroge `dist-tags.next` du registre npm et compare correctement à la version courante (y compris si elle est elle-même une pre-release).
+
+## 7. Risques & open questions
+
+### Risques
+
+1. **`claude update` non disponible sur toutes les versions / méthodes d'install.** Mitigation : tester en priorité, fallback vers la commande spécifique au package manager détecté.
+2. **Restart du ws-server casse une session active.** Mitigation : prévenir clairement dans la notification ("The bridge will restart") et n'updater que sur action explicite. Optionnellement, refuser d'updater si une session est en cours et proposer "Update Later".
+3. **npm registry rate limiting.** Très peu probable à 1 req/24h/user, mais : ajouter un User-Agent identifiant l'extension pour traçabilité.
+4. **Le binaire `claude` n'est pas sur le PATH de Nova** (problème nvm documenté dans CLAUDE.md §Gotchas). Le setting `claudecode.claudeCommand` du workspace permet déjà l'override, donc réutiliser.
+
+### Décisions
+
+- **Q1 — Canal `@next` supporté** : enum `stable` / `next` dans les settings, default `stable`. Quand `next` est sélectionné, le check distant utilise `https://registry.npmjs.org/@anthropic-ai/claude-code` (root, pas `/latest`) et lit `dist-tags.next`.
+- **Q2 — Version dans le sidebar** : nouvelle section `Claude Code` dans le sidebar existant, affichant un item avec la version courante et un état (à jour / update dispo / not installed / unknown). Clic = invoque `claudecode.checkForUpdates`. Mise à jour du label au démarrage et après chaque check.
+- **Q3 — Check auto au lancement de l'extension** : fire dans `activate()`, donc à chaque ouverture de workspace Nova. Throttling 24h via `lastCheckedAt` évite la sur-fréquence pour l'utilisateur qui ouvre plusieurs workspaces / sessions par jour.
+
+## 8. Out of scope explicite
+
+- Vérifier la version de Node.js utilisée par le ws-server (déjà géré par le check au startup actuel).
+- Vérifier la version du protocole MCP — couplée à la version de Claude Code, pas de check séparé.
+- Notification UI in-editor (statut bar custom) — pas d'API stable côté Nova.
+
+## 9. Plan de livraison
+
+1. **PR 1** — `update-check.js` module + tests unitaires sur le comparateur semver et la détection de méthode d'install.
+2. **PR 2** — Wire-up dans `main.js`, ajout des settings/commandes dans `extension.json`, smoke test manuel (commande explicite).
+3. **PR 3** — Auto-check au startup avec throttling 24h, settings de désactivation.
+4. **PR 4** — Update flow complet avec restart du ws-server, error handling, copy log.
+
+Release ciblée : **v0.6.0**.

--- a/spike/m0-node-pty/.gitignore
+++ b/spike/m0-node-pty/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.log

--- a/spike/m0-node-pty/SPIKE.md
+++ b/spike/m0-node-pty/SPIKE.md
@@ -1,0 +1,91 @@
+# M0 Spike — node-pty validation report
+
+**Date :** 2026-05-28
+**Statut :** ✅ PASS — feu vert pour M1
+**Environnement testé :** macOS 26.5 (Darwin), arm64, Node v22.22.0 (nvm)
+
+## Objectif
+
+Valider qu'on peut charger `node-pty` (module natif) dans le subprocess Node spawné par Nova, et spawn le binaire `claude` à travers une vraie PTY, avant d'engager 3-5 semaines sur M1-M3.
+
+## Résultats
+
+| Test | Description | Statut | Détails |
+|---|---|---|---|
+| T1 | `pty.spawn('/bin/zsh')` + écho d'un sentinel | ✅ PASS | Sentinel reçu en < 500 ms |
+| T2 | `pty.spawn(claude, ['--version'])` | ✅ PASS | Capture « 2.1.153 (Claude Code) » |
+| T3 | Même test depuis subprocess avec PATH dépouillé (`/usr/bin:/bin:/usr/sbin:/sbin`), env Nova-like | ✅ PASS | node-pty charge et fonctionne sans dépendre du PATH |
+
+## Caractéristiques du binaire natif
+
+```
+File:     pty.node (Mach-O 64-bit bundle arm64)
+Size:     84 KB
+Linkage:  /usr/lib/libc++.1.dylib + /usr/lib/libSystem.B.dylib
+Signing:  adhoc, linker-signed (CodeDirectory v=20400)
+```
+
+**Implications :**
+- Aucune dépendance dynamique externe → pas de runtime à shipper
+- Ad-hoc signed → Gatekeeper laisse passer le chargement in-process (pas de quarantaine sur les fichiers livrés via Nova Extensions)
+- 84 KB par architecture → bundling de 2 arches = ~170 KB de surcharge pour l'extension, acceptable
+
+## Surprise : @homebridge ne ship PAS de prebuilds darwin
+
+Malgré son nom (`node-pty-prebuilt-multiarch`), `@homebridge/node-pty-prebuilt-multiarch@0.13.1` ne fournit que des prebuilds **Linux** (arm, arm64, ia32, x64). Sur macOS, le binaire a été **compilé localement** par `node-gyp` pendant `npm install` — ce qui a marché uniquement parce que Xcode est installé sur la machine de dev.
+
+**→ Inutilisable tel quel pour la distribution.** Un user qui installe l'extension Nova sans Xcode CLI tools verrait `npm install` échouer.
+
+## Recommandation pour M1/M3 — utiliser `@lydell/node-pty`
+
+`@lydell/node-pty@1.2.0-beta.12` (publié mars 2025) ship des prebuilds **par plateforme via optionalDependencies**, pattern identique à esbuild/swc :
+
+```
+@lydell/node-pty-darwin-arm64    ← celui qu'on veut
+@lydell/node-pty-darwin-x64      ← pour Macs Intel
+@lydell/node-pty-linux-x64
+@lydell/node-pty-linux-arm64
+@lydell/node-pty-win32-x64
+@lydell/node-pty-win32-arm64
+```
+
+npm sélectionne automatiquement le bon paquet selon `process.platform` + `process.arch` au moment de l'install. Pas de node-gyp, pas de Xcode requis chez l'utilisateur final.
+
+**À valider en M1 :** refaire les 3 tests avec `@lydell/node-pty` pour confirmer feature parity. API publique identique (basée sur le node-pty officiel 1.x).
+
+## Stratégie de packaging recommandée (à finaliser en M3)
+
+1. **Pendant le dev** : `@lydell/node-pty` comme dépendance normale dans `Scripts/package.json`
+2. **Build de release** : un script `npm run bundle-native` qui :
+   - Installe `@lydell/node-pty-darwin-arm64` et `@lydell/node-pty-darwin-x64` séparément
+   - Extrait les `.node` dans `Scripts/native/darwin-arm64/pty.node` et `Scripts/native/darwin-x64/pty.node`
+   - Modifie ws-server.js pour faire `require('./native/${process.arch}/pty.node')`
+3. **Extension finale** : ne ship que les fichiers nécessaires, pas tout `node_modules/`
+4. **Estimation taille** : ~170 KB pour les 2 binaires (vs ~12 MB de `node_modules/@homebridge/...` complet)
+
+## Risques résiduels (acceptables)
+
+| Risque | Probabilité | Mitigation |
+|---|---|---|
+| `@lydell/node-pty` est en beta (1.2.0-beta.12) | Faible | API stable depuis node-pty 1.x officiel ; fallback `node-pty-prebuilt-multiarch` 0.10.x si besoin |
+| Nova bumpe son Node interne et casse ABI | Très faible | node-pty 1.x utilise N-API → ABI stable across Node versions |
+| macOS update casse signature ad-hoc | Très faible | Pattern utilisé par des milliers d'extensions VS Code via Electron — couvert par Apple |
+| User sur Mac Intel ancien | Faible | Bundling darwin-x64 + darwin-arm64 couvre tout depuis macOS 10.15 |
+
+## Verdict
+
+**M0 est un go.** Aucun blocker technique pour M1. La distribution (M3) a un chemin propre via `@lydell/node-pty`. Le coût en taille d'extension est négligeable (~170 KB).
+
+## Prochaines étapes (M1)
+
+1. Refaire T1-T3 avec `@lydell/node-pty` pour confirmer parité
+2. Coder le bridge minimal : xterm.js dans Preview tab + WS `/pty` côté ws-server, sans encore intégrer `claude` (juste `/bin/zsh`)
+3. Valider que xterm.js dans le WebKit de Nova Preview se comporte correctement (resize, ANSI colors, mouse events)
+
+## Fichiers du spike
+
+- `package.json` — deps de test
+- `test1-basic.js` — spawn zsh + sentinel
+- `test2-claude.js` — claude --version
+- `test3-isolated.js` + `test3-child.js` — subprocess Nova-like
+- `SPIKE.md` — ce fichier

--- a/spike/m0-node-pty/package.json
+++ b/spike/m0-node-pty/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "m0-node-pty-spike",
+  "version": "0.0.0",
+  "private": true,
+  "description": "M0 spike — validate node-pty loads + spawns claude in a Nova-like subprocess",
+  "scripts": {
+    "test:basic": "node test1-basic.js",
+    "test:claude": "node test2-claude.js",
+    "test:isolated": "node test3-isolated.js"
+  },
+  "dependencies": {
+    "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1"
+  }
+}

--- a/spike/m0-node-pty/test1-basic.js
+++ b/spike/m0-node-pty/test1-basic.js
@@ -1,0 +1,51 @@
+// Test 1 — pty.spawn('zsh') + capture echo output
+// Validates that node-pty loads and produces a usable PTY.
+
+const pty = require("@homebridge/node-pty-prebuilt-multiarch");
+
+console.log("[test1] node-pty loaded:", typeof pty.spawn === "function");
+console.log("[test1] process.arch =", process.arch, "node =", process.version);
+
+const term = pty.spawn("/bin/zsh", ["-i"], {
+  name: "xterm-256color",
+  cols: 80,
+  rows: 24,
+  cwd: process.cwd(),
+  env: { ...process.env, TERM: "xterm-256color" },
+});
+
+let captured = "";
+let resolved = false;
+
+term.onData((data) => {
+  captured += data;
+  process.stdout.write(data);
+  if (captured.includes("MARC_M0_SENTINEL_OK") && !resolved) {
+    resolved = true;
+    console.log("\n[test1] PASS — sentinel echoed back through PTY");
+    term.kill();
+  }
+});
+
+term.onExit(({ exitCode, signal }) => {
+  console.log(`\n[test1] PTY exited code=${exitCode} signal=${signal}`);
+  if (!resolved) {
+    console.error("[test1] FAIL — sentinel never appeared in PTY output");
+    process.exit(1);
+  }
+  process.exit(0);
+});
+
+// Give zsh a moment to print its prompt, then send the test command.
+setTimeout(() => {
+  console.log("\n[test1] writing: echo MARC_M0_SENTINEL_OK");
+  term.write("echo MARC_M0_SENTINEL_OK\n");
+}, 500);
+
+setTimeout(() => {
+  if (!resolved) {
+    console.error("[test1] FAIL — timeout (5s) without sentinel");
+    term.kill();
+    process.exit(1);
+  }
+}, 5000);

--- a/spike/m0-node-pty/test2-claude.js
+++ b/spike/m0-node-pty/test2-claude.js
@@ -1,0 +1,43 @@
+// Test 2 — pty.spawn('claude', ['--version'])
+// Smoke test: does the claude binary work when spawned inside a PTY?
+
+const pty = require("@homebridge/node-pty-prebuilt-multiarch");
+const path = require("path");
+const os = require("os");
+
+const claudePath = path.join(os.homedir(), ".local", "bin", "claude");
+console.log("[test2] claude path =", claudePath);
+
+const term = pty.spawn(claudePath, ["--version"], {
+  name: "xterm-256color",
+  cols: 80,
+  rows: 24,
+  cwd: process.cwd(),
+  env: { ...process.env, TERM: "xterm-256color" },
+});
+
+let captured = "";
+
+term.onData((data) => {
+  captured += data;
+  process.stdout.write(data);
+});
+
+term.onExit(({ exitCode, signal }) => {
+  console.log(`\n[test2] PTY exited code=${exitCode} signal=${signal}`);
+  console.log(`[test2] captured ${captured.length} bytes`);
+  const versionMatch = captured.match(/\d+\.\d+\.\d+/);
+  if (versionMatch) {
+    console.log(`[test2] PASS — claude version detected: ${versionMatch[0]}`);
+    process.exit(0);
+  } else {
+    console.error("[test2] FAIL — no semver pattern found in output");
+    process.exit(1);
+  }
+});
+
+setTimeout(() => {
+  console.error("[test2] FAIL — timeout (10s)");
+  term.kill();
+  process.exit(1);
+}, 10000);

--- a/spike/m0-node-pty/test3-child.js
+++ b/spike/m0-node-pty/test3-child.js
@@ -1,0 +1,64 @@
+// test3-child.js — runs as a subprocess simulating ws-server.js spawned by Nova.
+// Parent strips PATH down to a Nova-like minimum; this child must still:
+//   1) require() node-pty (loads native .node)
+//   2) pty.spawn() claude via absolute path
+//   3) capture --version output
+//   4) signal success on stdout (Nova receives JSON lines)
+
+const path = require("path");
+const os = require("os");
+
+function emit(level, msg, data) {
+  process.stdout.write(JSON.stringify({ level, msg, data }) + "\n");
+}
+
+emit("info", "child started", {
+  arch: process.arch,
+  node: process.version,
+  cwd: process.cwd(),
+  pathEnv: process.env.PATH || "(empty)",
+  homeEnv: process.env.HOME,
+});
+
+let pty;
+try {
+  pty = require("@homebridge/node-pty-prebuilt-multiarch");
+  emit("info", "node-pty loaded OK");
+} catch (err) {
+  emit("error", "node-pty load FAILED", { message: err.message, stack: err.stack });
+  process.exit(1);
+}
+
+const claudePath = path.join(os.homedir(), ".local", "bin", "claude");
+emit("info", "spawning claude", { binary: claudePath });
+
+const term = pty.spawn(claudePath, ["--version"], {
+  name: "xterm-256color",
+  cols: 80,
+  rows: 24,
+  cwd: os.homedir(),
+  env: { ...process.env, TERM: "xterm-256color" },
+});
+
+let captured = "";
+term.onData((data) => {
+  captured += data;
+});
+
+term.onExit(({ exitCode, signal }) => {
+  emit("info", "pty exited", { exitCode, signal, captured: captured.trim() });
+  const version = captured.match(/\d+\.\d+\.\d+/);
+  if (version) {
+    emit("result", "PASS", { version: version[0] });
+    process.exit(0);
+  } else {
+    emit("result", "FAIL", { reason: "no version in output", raw: captured });
+    process.exit(1);
+  }
+});
+
+setTimeout(() => {
+  emit("result", "FAIL", { reason: "timeout" });
+  term.kill();
+  process.exit(1);
+}, 10000);

--- a/spike/m0-node-pty/test3-isolated.js
+++ b/spike/m0-node-pty/test3-isolated.js
@@ -1,0 +1,52 @@
+// test3-isolated.js — parent script that mimics how Nova spawns ws-server.js.
+// Strips PATH to the bare minimum (no nvm, no /usr/local/bin), passes only
+// HOME + a Nova-like trimmed env, and verifies the child still works.
+
+const { spawn } = require("child_process");
+const path = require("path");
+
+// Nova does NOT source .zshrc — its environment is what login provides.
+// To simulate "worst case", we hand the child a stripped PATH that excludes
+// the nvm bin dir entirely. We launch the child via the SAME node we're
+// running under, by absolute path (which is how Nova would resolve it).
+const nodeBinary = process.execPath; // absolute path to current node
+const childScript = path.join(__dirname, "test3-child.js");
+
+console.log("[parent] launching child:", nodeBinary, childScript);
+console.log("[parent] using stripped PATH (no nvm, no /usr/local/bin)");
+
+const child = spawn(nodeBinary, [childScript], {
+  cwd: __dirname,
+  env: {
+    HOME: process.env.HOME,
+    USER: process.env.USER,
+    LANG: process.env.LANG || "en_US.UTF-8",
+    PATH: "/usr/bin:/bin:/usr/sbin:/sbin", // bare minimum, NO nvm, NO user bins
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+child.stdout.on("data", (chunk) => {
+  // child emits JSON lines — Nova reads them similarly
+  chunk
+    .toString("utf8")
+    .split("\n")
+    .filter(Boolean)
+    .forEach((line) => {
+      try {
+        const msg = JSON.parse(line);
+        console.log(`[child:${msg.level}]`, msg.msg, msg.data ?? "");
+      } catch {
+        console.log("[child:raw]", line);
+      }
+    });
+});
+
+child.stderr.on("data", (chunk) => {
+  process.stderr.write(`[child:stderr] ${chunk}`);
+});
+
+child.on("exit", (code, signal) => {
+  console.log(`[parent] child exited code=${code} signal=${signal}`);
+  process.exit(code ?? 1);
+});

--- a/spike/m0-node-pty/test4-interactive.js
+++ b/spike/m0-node-pty/test4-interactive.js
@@ -1,0 +1,87 @@
+// Test 4 — interactive claude session through node-pty.
+//
+// Spawns 'claude' (no args = TUI mode) inside a real PTY, then bridges:
+//   - parent stdin  → pty.write   (keystrokes flow through, raw mode)
+//   - pty stdout    → parent stdout (TUI rendering: colors, cursor, boxes)
+//   - SIGWINCH       → pty.resize  (terminal resizes propagate)
+//
+// What this proves end-to-end:
+//   1. claude detects the PTY as a TTY → enters interactive TUI mode
+//   2. Keypresses (including Ctrl+chars, arrow keys, Esc) flow through
+//   3. ANSI escape sequences render correctly
+//   4. Resize handling works
+//
+// Exit: type /quit inside claude, OR press Ctrl+\ (SIGQUIT) in the parent
+// terminal to forcibly tear down the wrapper.
+
+const pty = require("@homebridge/node-pty-prebuilt-multiarch");
+const path = require("path");
+const os = require("os");
+
+const claudePath = path.join(os.homedir(), ".local", "bin", "claude");
+
+console.log("─".repeat(60));
+console.log(" M0 Test 4 — interactive claude session via node-pty");
+console.log("─".repeat(60));
+console.log(` claude binary : ${claudePath}`);
+console.log(` terminal size : ${process.stdout.columns}×${process.stdout.rows}`);
+console.log(` TERM          : ${process.env.TERM}`);
+console.log(" Exit          : type /quit inside claude, or Ctrl+\\ to force");
+console.log("─".repeat(60));
+console.log("");
+
+const term = pty.spawn(claudePath, [], {
+  name: "xterm-256color",
+  cols: process.stdout.columns || 80,
+  rows: process.stdout.rows || 24,
+  cwd: process.cwd(),
+  env: { ...process.env, TERM: "xterm-256color" },
+});
+
+// PTY output → parent stdout (the TUI you see is fully rendered by claude)
+term.onData((data) => {
+  process.stdout.write(data);
+});
+
+// Put parent stdin into raw mode so every keystroke goes straight to claude
+// (no line buffering, no echo, no Ctrl+C handling by the parent shell).
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
+process.stdin.resume();
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  // Ctrl+\ (0x1c) = wrapper kill switch — bypasses claude
+  if (chunk === "\x1c") {
+    cleanup(0, "wrapper kill switch (Ctrl+\\)");
+    return;
+  }
+  term.write(chunk);
+});
+
+// Forward terminal resize events
+process.stdout.on("resize", () => {
+  const cols = process.stdout.columns;
+  const rows = process.stdout.rows;
+  term.resize(cols, rows);
+});
+
+term.onExit(({ exitCode, signal }) => {
+  cleanup(exitCode ?? 0, `claude exited (code=${exitCode}, signal=${signal})`);
+});
+
+function cleanup(code, reason) {
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(false);
+  }
+  process.stdin.pause();
+  // small spacer so the next shell prompt isn't glued to claude's last line
+  process.stdout.write(`\n\n─── ${reason} ───\n`);
+  process.exit(code);
+}
+
+process.on("SIGINT", () => {
+  // Forward Ctrl+C to claude (don't kill the wrapper)
+  term.write("\x03");
+});

--- a/spike/m1-agent-sdk/.gitignore
+++ b/spike/m1-agent-sdk/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+*.log
+.anthropic-key

--- a/spike/m1-agent-sdk/SPIKE.md
+++ b/spike/m1-agent-sdk/SPIKE.md
@@ -1,0 +1,197 @@
+# M1 Spike — Claude Agent SDK validation
+
+**Date :** 2026-05-28
+**Statut :** ⏳ En attente d'exécution par Marc (API key requise)
+**Environnement :** macOS 26.5, Node v22.22.0, arch arm64
+
+## Objectif
+
+Valider que `@anthropic-ai/claude-agent-sdk` est le bon backend pour la chat UI Nova (chemin B de notre exploration architecturale), avant d'investir dans le sprint complet.
+
+## Ce qu'on a vérifié sans clé API
+
+### Install propre
+
+```bash
+npm install --no-audit --no-fund
+# added 101 packages in 4s — pas d'erreurs, pas de node-gyp
+```
+
+### Distribution : excellente
+
+Le SDK suit le **même pattern de prebuilds que @lydell/node-pty** — optional dependencies par plateforme :
+
+```
+@anthropic-ai/claude-agent-sdk-darwin-arm64     ← sélectionné sur ce Mac
+@anthropic-ai/claude-agent-sdk-darwin-x64
+@anthropic-ai/claude-agent-sdk-linux-{x64,arm64,…}
+@anthropic-ai/claude-agent-sdk-win32-{x64,arm64}
+```
+
+Le `darwin-arm64` package contient le binaire `claude` standalone (le SDK est en fait un wrapper Node autour du CLI Claude Code). **Aucun build chez l'utilisateur final**, npm sélectionne automatiquement la bonne arch.
+
+### API publique confirmée
+
+```typescript
+// Streaming d'events (ce qu'on veut pour la chat UI)
+function query(params: { prompt: string | AsyncIterable<...>; options?: Options }): Query;
+// Query est un AsyncGenerator<SDKMessage, void>
+
+// In-process tool (pour wrapper les opérations Nova)
+function tool<Schema>(name, description, zodSchema, handler): SdkMcpToolDefinition;
+
+// Wrapping en serveur MCP in-process
+function createSdkMcpServer({ name, tools }): McpSdkServerConfigWithInstance;
+```
+
+### Event types (extrait du sdk.d.ts)
+
+```
+SDKMessage =
+  | SDKAssistantMessage          ← text chunks + tool_use blocks (le pain pour la chat UI)
+  | SDKUserMessage               ← tool_result blocks viennent ici
+  | SDKResultMessage             ← final (success/error, usage, cost)
+  | SDKSystemMessage             ← init avec session_id, model, tools available
+  | SDKPartialAssistantMessage   ← fine-grained streaming
+  | SDKToolProgressMessage       ← started/in_progress/completed
+  | SDKThinkingTokensMessage     ← extended thinking
+  | SDKHookStartedMessage
+  | SDKHookProgressMessage
+  | SDKHookResponseMessage
+  | SDKTaskNotificationMessage
+  | SDKTaskStartedMessage
+  | SDKTaskUpdatedMessage
+  | SDKTaskProgressMessage
+  | SDKMemoryRecallMessage
+  | SDKRateLimitEvent
+  | SDKAuthStatusMessage
+  | ... (32 types au total)
+```
+
+Riche taxonomie — on a tout pour faire une UI live (progress bars, sessions, hooks visibility, rate limit warnings, memory recall, etc.).
+
+### Peer dependencies
+
+- `@anthropic-ai/sdk` >= 0.93.0 (sous-jacent)
+- `@modelcontextprotocol/sdk` ^1.29.0 (MCP types)
+- `zod` ^4.0.0 (schemas d'outils)
+
+Tous installés automatiquement.
+
+## Ce que les tests valideront (Marc à exécuter)
+
+### Prérequis : ANTHROPIC_API_KEY
+
+Option A — depuis le shell :
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Option B — via 1Password (recommandé selon tes conventions) :
+```bash
+eval $(op signin)
+export ANTHROPIC_API_KEY=$(op read "op://Private/Anthropic API Key/credential")
+```
+
+Si tu n'as pas encore de clé, en générer une à :
+https://console.anthropic.com/settings/keys
+
+### Test 1 — query basique sans tools
+
+```bash
+cd /Users/mbourget/Projects/okapi-ca/claudecode-nova/spike/m1-agent-sdk
+node test1-basic.mjs
+```
+
+**Ce qu'on doit voir :**
+- Connexion à l'API
+- Stream des chunks de texte (la réponse de Claude s'affiche progressivement)
+- Event `[system:init]` avec session_id
+- Event `[result]` final avec usage tokens et coût
+- Compteurs par type d'event en fin
+
+**Valide :** install, auth, streaming basique, mapping event → UI.
+
+### Test 2 — query avec tool in-process
+
+```bash
+node test2-with-tool.mjs
+```
+
+**Ce qu'on doit voir :**
+- Claude appelle `nova_listFiles` puis `nova_openFile("src/auth.ts")`
+- Nos handlers in-process s'exécutent (logs `[tool:...] called`)
+- Tool results streams back vers Claude
+- Claude répond en identifiant le bypass admin
+
+**Valide :** le pattern in-process tool — c'est exactement ce qu'on utilisera dans ws-server.js pour wrapper les opérations Nova.
+
+## Architecture résultante pour le sprint complet
+
+```
+[Nova main.js]
+    ↕ JSON lines (existant)
+[ws-server.js]
+    ├── WebSocket MCP /mcp        ← Mode CLI : claude externe (inchangé)
+    │
+    └── HTTP/WS /chat              ← Mode Chat UI : Preview tab WebKit
+        ├── @anthropic-ai/claude-agent-sdk
+        │   └── createSdkMcpServer("nova", [
+        │         tool("nova_openFile", schema, async (args) => {
+        │           // round-trip JSON ligne → main.js → résultat
+        │         }),
+        │         tool("nova_openDiff", ...),
+        │         tool("nova_getDiagnostics", ...),
+        │         // ... wrapper les 10+ tools existants
+        │       ])
+        └── render des events SDKMessage en chat UI HTML
+```
+
+Aucun changement protocolaire entre `main.js` et `ws-server.js` — les tools existants sont juste exposés deux fois : via le WebSocket MCP (pour le CLI externe) ET via les wrappers in-process (pour le SDK).
+
+## Findings — distribution
+
+Pour packager l'extension Nova finale :
+
+| Stratégie | Taille | Complexité install user |
+|---|---|---|
+| Bundler `@anthropic-ai/claude-agent-sdk` complet (avec tout `node_modules/`) | ~50-80 MB | Zéro (rien à faire) |
+| Ne bundler que le SDK + darwin-arm64 + darwin-x64 + peer deps | ~15-25 MB | Zéro |
+| Ne bundler que le `pty.node` et faire npm install à l'activation | ~1 MB | Nécessite `node` + `npm` sur le PATH (fragile) |
+
+**Recommandation pour M3** : bundle la deuxième option. ~20 MB, install zéro-friction, marche partout sur darwin.
+
+## Coût estimé d'usage (à valider par Marc en lançant les tests)
+
+D'après le pricing public Anthropic à la date du spike :
+- Sonnet 4.6 : ~$3/M tokens input, ~$15/M output
+- Opus 4.7 : ~$15/M input, ~$75/M output
+
+Un test simple comme test1 (3 phrases) devrait coûter < $0.01. Test2 (avec 2 tool calls) ~$0.02.
+
+À partir du **15 juin 2026**, les abonnements Claude Pro/Max incluent un crédit SDK distinct (à confirmer dans les docs Anthropic à la sortie de la feature).
+
+## Verdict (préliminaire, à confirmer après run)
+
+**Architecturalement** : le chemin B (SDK direct) est solide. Pattern de distribution propre, API riche, event taxonomy adéquate pour une chat UI, in-process tools pour wrapper Nova sans MCP intermédiaire.
+
+**À confirmer** : il faut que tu lances les deux tests pour valider que :
+1. L'auth API key marche (sanity check)
+2. Le pricing est acceptable pour ton workflow
+3. La latence du stream est confortable (sub-second sur les premiers chunks)
+
+Si les deux tests passent, on s'engage sur le sprint Chat UI complet.
+
+## Fichiers du spike
+
+- `package.json` — dépendance unique (`@anthropic-ai/claude-agent-sdk`)
+- `test1-basic.mjs` — query streaming sans tools
+- `test2-with-tool.mjs` — query + in-process tools mockés (pattern Nova)
+- `SPIKE.md` — ce fichier
+
+## Notes complémentaires
+
+- Le SDK ne supporte **pas** WebSocket comme transport MCP. Pour Nova on utilise **in-process** tools, pas un MCP server externe.
+- Le SDK ne réutilise **pas** les credentials `~/.claude/` du CLI. Auth = API key uniquement.
+- Le SDK utilise **Zod v4** (pas v3) pour les schemas d'outils — important pour TypeScript.
+- Le binaire `claude` bundlé dans `@anthropic-ai/claude-agent-sdk-darwin-arm64` est le même que le CLI standalone, contrôlé par le SDK via flags non-interactifs.

--- a/spike/m1-agent-sdk/package.json
+++ b/spike/m1-agent-sdk/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "m1-agent-sdk-spike",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "M1 spike — validate @anthropic-ai/claude-agent-sdk for Nova chat UI backend",
+  "scripts": {
+    "test:basic": "node test1-basic.mjs",
+    "test:tool": "node test2-with-tool.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+  }
+}

--- a/spike/m1-agent-sdk/test1-basic.mjs
+++ b/spike/m1-agent-sdk/test1-basic.mjs
@@ -1,0 +1,109 @@
+// Test 1 — basic query() without tools.
+//
+// Validates :
+//   1. The SDK loads correctly in Node 22
+//   2. Authentication via ANTHROPIC_API_KEY works
+//   3. We can stream events from a simple prompt
+//   4. The event taxonomy matches what we expect for a chat UI
+//
+// Usage :
+//   export ANTHROPIC_API_KEY="sk-ant-..."
+//   node test1-basic.mjs
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ERROR: set ANTHROPIC_API_KEY env var before running.");
+  console.error("Get one at https://console.anthropic.com/settings/keys");
+  process.exit(1);
+}
+
+console.log("─".repeat(60));
+console.log(" M1 Test 1 — basic query, no tools");
+console.log(`─ Node: ${process.version}, arch: ${process.arch}`);
+console.log("─".repeat(60));
+
+const prompt = "In exactly 3 short sentences, explain what a pseudo-terminal (PTY) is. No code.";
+
+console.log("\n[user]", prompt, "\n");
+
+// Counters for the final summary
+const counts = {};
+let firstAssistantText = null;
+let sessionId = null;
+
+const startedAt = Date.now();
+
+const q = query({
+  prompt,
+  options: {
+    // No tools at all — we want a pure text-streaming validation
+    allowedTools: [],
+    // Use the default model (lets SDK pick)
+  },
+});
+
+for await (const msg of q) {
+  counts[msg.type] = (counts[msg.type] || 0) + 1;
+
+  // Capture session_id for potential resume tests later
+  if (msg.session_id && !sessionId) sessionId = msg.session_id;
+
+  switch (msg.type) {
+    case "system":
+      if (msg.subtype === "init") {
+        console.log(`[system:init] session=${msg.session_id?.slice(0, 8)}… model=${msg.model || "default"}`);
+      }
+      break;
+
+    case "assistant": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+          if (!firstAssistantText) firstAssistantText = block.text;
+        } else if (block.type === "tool_use") {
+          console.log(`\n[tool_use] ${block.name}(${JSON.stringify(block.input).slice(0, 80)})`);
+        } else if (block.type === "thinking") {
+          // extended thinking
+        }
+      }
+      break;
+    }
+
+    case "result": {
+      const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      console.log(`\n\n─ Result: ${msg.subtype}`);
+      if (msg.subtype === "success") {
+        if (msg.usage) {
+          console.log(`─ Tokens: in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
+        }
+        if (msg.total_cost_usd != null) {
+          console.log(`─ Cost: $${msg.total_cost_usd.toFixed(4)} USD`);
+        }
+      } else {
+        console.log(`─ Error:`, msg);
+      }
+      console.log(`─ Elapsed: ${elapsed}s`);
+      break;
+    }
+
+    case "stream_event":
+    case "partial_assistant":
+      // These exist but are noisy; we skip
+      break;
+
+    default:
+      // Catch-all so we see anything unexpected
+      // (commented to keep output clean — uncomment for debugging)
+      // console.log(`\n[${msg.type}]`, JSON.stringify(msg).slice(0, 120));
+      break;
+  }
+}
+
+console.log("\n─ Event type counts:");
+for (const [type, n] of Object.entries(counts).sort()) {
+  console.log(`    ${type.padEnd(28)} ${n}`);
+}
+console.log(`─ Session ID: ${sessionId ?? "(none captured)"}`);
+console.log("─ Test 1 PASS\n");

--- a/spike/m1-agent-sdk/test2-with-tool.mjs
+++ b/spike/m1-agent-sdk/test2-with-tool.mjs
@@ -1,0 +1,173 @@
+// Test 2 — query() with an in-process MCP tool (mocked Nova).
+//
+// This is the pattern we'll use in ws-server.js : Nova editor operations
+// (openFile, openDiff, etc.) wrapped as in-process tools that the SDK can
+// invoke directly. No external MCP transport needed.
+//
+// Validates :
+//   1. createSdkMcpServer() registers in-process tools correctly
+//   2. tool() with a Zod schema validates inputs
+//   3. The SDK invokes the handler and streams tool_use + tool_progress events
+//   4. The handler can be async (simulates the round-trip to Nova main.js)
+//
+// Usage :
+//   export ANTHROPIC_API_KEY="sk-ant-..."
+//   node test2-with-tool.mjs
+
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ERROR: set ANTHROPIC_API_KEY env var before running.");
+  process.exit(1);
+}
+
+console.log("─".repeat(60));
+console.log(" M1 Test 2 — query with in-process tool (mock Nova)");
+console.log("─".repeat(60));
+
+// Mock fixture : a fake workspace with two files
+const fakeWorkspace = {
+  "src/auth.ts": `export function login(user: string, pwd: string) {
+  // FIXME: hardcoded admin bypass — security issue
+  if (user === "admin") return { ok: true };
+  return checkCredentials(user, pwd);
+}`,
+  "README.md": "# Project\n\nThis is a fake project for the M1 spike.",
+};
+
+// In-process tool — this is exactly the shape we'd use to wrap real Nova
+// operations via ws-server.js → main.js round-trip.
+const novaOpenFile = tool(
+  "nova_openFile",
+  "Open and read the contents of a file in the Nova editor workspace.",
+  {
+    path: z.string().describe("Relative path to the file from the workspace root"),
+  },
+  async (args) => {
+    console.log(`\n[tool:nova_openFile] called with path="${args.path}"`);
+
+    // Simulate the async round-trip (ws-server → main.js → editor → back)
+    await new Promise((r) => setTimeout(r, 50));
+
+    const content = fakeWorkspace[args.path];
+    if (content === undefined) {
+      return {
+        content: [{ type: "text", text: `Error: file not found: ${args.path}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: content }],
+    };
+  },
+);
+
+const novaListFiles = tool(
+  "nova_listFiles",
+  "List all files in the Nova workspace.",
+  {},
+  async () => {
+    console.log(`\n[tool:nova_listFiles] called`);
+    await new Promise((r) => setTimeout(r, 50));
+    return {
+      content: [{ type: "text", text: Object.keys(fakeWorkspace).join("\n") }],
+    };
+  },
+);
+
+const novaServer = createSdkMcpServer({
+  name: "nova",
+  version: "0.0.0",
+  tools: [novaOpenFile, novaListFiles],
+});
+
+const prompt = "List the files in the workspace, then read src/auth.ts and tell me if there are any security issues. Keep your response under 100 words.";
+
+console.log("\n[user]", prompt, "\n");
+
+const startedAt = Date.now();
+const counts = {};
+const toolCalls = [];
+
+const q = query({
+  prompt,
+  options: {
+    mcpServers: {
+      nova: novaServer,
+    },
+    // Wildcard auto-approve for our in-process server, deny everything else
+    allowedTools: ["mcp__nova__nova_openFile", "mcp__nova__nova_listFiles"],
+  },
+});
+
+for await (const msg of q) {
+  counts[msg.type] = (counts[msg.type] || 0) + 1;
+
+  switch (msg.type) {
+    case "system":
+      if (msg.subtype === "init") {
+        console.log(`[system:init] session=${msg.session_id?.slice(0, 8)}…`);
+        if (msg.tools) console.log(`[system:init] tools available: ${msg.tools.length}`);
+      }
+      break;
+
+    case "assistant": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+        } else if (block.type === "tool_use") {
+          console.log(`\n[assistant→tool_use] ${block.name}(${JSON.stringify(block.input)})`);
+          toolCalls.push({ name: block.name, input: block.input });
+        }
+      }
+      break;
+    }
+
+    case "user": {
+      // Tool results come back as user messages with tool_result content blocks
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "tool_result") {
+          const text = Array.isArray(block.content)
+            ? block.content.map((c) => c.text).join("")
+            : block.content;
+          console.log(`\n[tool_result] ${text?.slice(0, 100) ?? "(empty)"}${text?.length > 100 ? "…" : ""}`);
+        }
+      }
+      break;
+    }
+
+    case "result": {
+      const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      console.log(`\n\n─ Result: ${msg.subtype}`);
+      if (msg.subtype === "success") {
+        if (msg.usage) {
+          console.log(`─ Tokens: in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
+        }
+        if (msg.total_cost_usd != null) {
+          console.log(`─ Cost: $${msg.total_cost_usd.toFixed(4)} USD`);
+        }
+      } else {
+        console.log(`─ Error:`, msg);
+      }
+      console.log(`─ Elapsed: ${elapsed}s`);
+      console.log(`─ Tool calls made: ${toolCalls.length}`);
+      for (const tc of toolCalls) {
+        console.log(`     - ${tc.name}(${JSON.stringify(tc.input)})`);
+      }
+      break;
+    }
+  }
+}
+
+console.log("\n─ Event type counts:");
+for (const [type, n] of Object.entries(counts).sort()) {
+  console.log(`    ${type.padEnd(28)} ${n}`);
+}
+
+const pass = toolCalls.length >= 1;
+console.log(pass ? "─ Test 2 PASS\n" : "─ Test 2 FAIL — no tool calls observed\n");
+process.exit(pass ? 0 : 1);

--- a/spike/m1-agent-sdk/test3-restricted.mjs
+++ b/spike/m1-agent-sdk/test3-restricted.mjs
@@ -1,0 +1,184 @@
+// Test 3 — query restreinte : 4 mitigations cumulées pour coût + isolation.
+//
+// Validations :
+//   1. Avec `tools: []`, les 115 outils built-in disparaissent
+//   2. Avec `settingSources: []`, le SDK ne charge plus les .claude/, CLAUDE.md, skills
+//   3. Avec `model: "claude-sonnet-4-6"`, le coût tombe drastiquement
+//   4. Avec uniquement nos mcp__nova__* exposés, Claude est forcé de les utiliser
+//
+// Objectif coût : passer de $0.50-0.70 (test2) à $0.01-0.05 par échange.
+//
+// Usage :
+//   export ANTHROPIC_API_KEY=$(op read "op://Private/Anthropic API Key/credential")
+//   node test3-restricted.mjs
+
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ERROR: set ANTHROPIC_API_KEY env var before running.");
+  process.exit(1);
+}
+
+console.log("─".repeat(60));
+console.log(" M1 Test 3 — restricted query (cost + isolation mitigations)");
+console.log("─".repeat(60));
+
+// Même fixture que test2
+const fakeWorkspace = {
+  "src/auth.ts": `export function login(user: string, pwd: string) {
+  // FIXME: hardcoded admin bypass — security issue
+  if (user === "admin") return { ok: true };
+  return checkCredentials(user, pwd);
+}`,
+  "README.md": "# Project\n\nThis is a fake project for the M1 spike.",
+};
+
+const novaOpenFile = tool(
+  "nova_openFile",
+  "Open and read the contents of a file in the Nova editor workspace.",
+  {
+    path: z.string().describe("Relative path to the file from the workspace root"),
+  },
+  async (args) => {
+    console.log(`\n[tool:nova_openFile] called with path="${args.path}"`);
+    await new Promise((r) => setTimeout(r, 50));
+    const content = fakeWorkspace[args.path];
+    if (content === undefined) {
+      return {
+        content: [{ type: "text", text: `Error: file not found: ${args.path}` }],
+        isError: true,
+      };
+    }
+    return { content: [{ type: "text", text: content }] };
+  },
+);
+
+const novaListFiles = tool(
+  "nova_listFiles",
+  "List all files in the Nova workspace.",
+  {},
+  async () => {
+    console.log(`\n[tool:nova_listFiles] called`);
+    await new Promise((r) => setTimeout(r, 50));
+    return {
+      content: [{ type: "text", text: Object.keys(fakeWorkspace).join("\n") }],
+    };
+  },
+);
+
+const novaServer = createSdkMcpServer({
+  name: "nova",
+  version: "0.0.0",
+  tools: [novaOpenFile, novaListFiles],
+});
+
+const prompt = "List the files in the workspace, then read src/auth.ts and tell me if there are any security issues. Keep your response under 100 words.";
+
+console.log("\n[user]", prompt, "\n");
+
+const startedAt = Date.now();
+const counts = {};
+const toolCalls = [];
+let toolsAvailableCount = null;
+
+const q = query({
+  prompt,
+  options: {
+    // MITIGATION 1 — modèle pas cher
+    model: "claude-sonnet-4-6",
+
+    // MITIGATION 2 — désactiver TOUS les tools built-in du SDK.
+    // Seuls les tools des mcpServers seront exposés.
+    tools: [],
+
+    // MITIGATION 3 — SDK isolation : pas de .claude/, CLAUDE.md, skills, rules
+    settingSources: [],
+
+    // MITIGATION 4 — nos tools Nova in-process
+    mcpServers: {
+      nova: novaServer,
+    },
+  },
+});
+
+for await (const msg of q) {
+  counts[msg.type] = (counts[msg.type] || 0) + 1;
+
+  switch (msg.type) {
+    case "system":
+      if (msg.subtype === "init") {
+        toolsAvailableCount = msg.tools?.length ?? null;
+        console.log(`[system:init] session=${msg.session_id?.slice(0, 8)}… model=${msg.model || "(default)"}`);
+        console.log(`[system:init] tools available: ${toolsAvailableCount}`);
+        if (toolsAvailableCount != null && toolsAvailableCount <= 5) {
+          console.log(`[system:init] tools: ${msg.tools.join(", ")}`);
+        }
+      }
+      break;
+
+    case "assistant": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+        } else if (block.type === "tool_use") {
+          console.log(`\n[assistant→tool_use] ${block.name}(${JSON.stringify(block.input)})`);
+          toolCalls.push({ name: block.name, input: block.input });
+        }
+      }
+      break;
+    }
+
+    case "user": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "tool_result") {
+          const text = Array.isArray(block.content)
+            ? block.content.map((c) => c.text).join("")
+            : block.content;
+          console.log(`\n[tool_result] ${text?.slice(0, 100) ?? "(empty)"}${text?.length > 100 ? "…" : ""}`);
+        }
+      }
+      break;
+    }
+
+    case "result": {
+      const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      console.log(`\n\n─ Result: ${msg.subtype}`);
+      if (msg.subtype === "success") {
+        if (msg.usage) {
+          console.log(`─ Tokens: in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
+        }
+        if (msg.total_cost_usd != null) {
+          console.log(`─ Cost: $${msg.total_cost_usd.toFixed(4)} USD`);
+        }
+      } else {
+        console.log(`─ Error:`, msg);
+      }
+      console.log(`─ Elapsed: ${elapsed}s`);
+      console.log(`─ Tool calls made: ${toolCalls.length}`);
+      for (const tc of toolCalls) {
+        console.log(`     - ${tc.name}(${JSON.stringify(tc.input)})`);
+      }
+      break;
+    }
+  }
+}
+
+console.log("\n─ Event type counts:");
+for (const [type, n] of Object.entries(counts).sort()) {
+  console.log(`    ${type.padEnd(28)} ${n}`);
+}
+
+// Critères de PASS
+const usedNovaTools = toolCalls.some((tc) => tc.name.startsWith("mcp__nova__"));
+const usedOnlyNovaTools = toolCalls.every((tc) => tc.name.startsWith("mcp__nova__"));
+
+console.log("\n─ Évaluation :");
+console.log(`    tools available count       : ${toolsAvailableCount} ${toolsAvailableCount != null && toolsAvailableCount < 10 ? "✓" : "(attendu: <10)"}`);
+console.log(`    Claude a utilisé nova_*      : ${usedNovaTools ? "✓ OUI" : "✗ NON"}`);
+console.log(`    Aucun tool SDK built-in      : ${usedOnlyNovaTools ? "✓" : "✗"}`);
+console.log(`    → Comparer le coût ci-dessus au test2 ($0.6663). Objectif < $0.10.\n`);
+
+process.exit(usedNovaTools && usedOnlyNovaTools ? 0 : 1);

--- a/spike/m1-agent-sdk/test4-approved.mjs
+++ b/spike/m1-agent-sdk/test4-approved.mjs
@@ -1,0 +1,189 @@
+// Test 4 — test3 + auto-approval des tools Nova via allowedTools.
+//
+// Test3 a prouvé que les mitigations (model, tools, settingSources) réduisent
+// le coût de 77× et restreignent l'inventaire. Mais le SDK demande encore une
+// permission user avant chaque tool call — comportement par défaut du CLI
+// Claude Code. Pour notre chat UI, nos tools Nova sont de confiance (on les a
+// définis nous-mêmes), donc on les auto-approuve via `allowedTools`.
+//
+// Si ce test passe, la config est production-ready pour le sprint Chat UI.
+//
+// Usage :
+//   export ANTHROPIC_API_KEY=$(op read "op://Private/Anthropic API Key/credential")
+//   node test4-approved.mjs
+
+import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ERROR: set ANTHROPIC_API_KEY env var before running.");
+  process.exit(1);
+}
+
+console.log("─".repeat(60));
+console.log(" M1 Test 4 — auto-approved Nova tools (production-ready config)");
+console.log("─".repeat(60));
+
+const fakeWorkspace = {
+  "src/auth.ts": `export function login(user: string, pwd: string) {
+  // FIXME: hardcoded admin bypass — security issue
+  if (user === "admin") return { ok: true };
+  return checkCredentials(user, pwd);
+}`,
+  "README.md": "# Project\n\nThis is a fake project for the M1 spike.",
+};
+
+const novaOpenFile = tool(
+  "nova_openFile",
+  "Open and read the contents of a file in the Nova editor workspace.",
+  {
+    path: z.string().describe("Relative path to the file from the workspace root"),
+  },
+  async (args) => {
+    console.log(`\n[tool:nova_openFile] called with path="${args.path}"`);
+    await new Promise((r) => setTimeout(r, 50));
+    const content = fakeWorkspace[args.path];
+    if (content === undefined) {
+      return {
+        content: [{ type: "text", text: `Error: file not found: ${args.path}` }],
+        isError: true,
+      };
+    }
+    return { content: [{ type: "text", text: content }] };
+  },
+);
+
+const novaListFiles = tool(
+  "nova_listFiles",
+  "List all files in the Nova workspace.",
+  {},
+  async () => {
+    console.log(`\n[tool:nova_listFiles] called`);
+    await new Promise((r) => setTimeout(r, 50));
+    return {
+      content: [{ type: "text", text: Object.keys(fakeWorkspace).join("\n") }],
+    };
+  },
+);
+
+const novaServer = createSdkMcpServer({
+  name: "nova",
+  version: "0.0.0",
+  tools: [novaOpenFile, novaListFiles],
+});
+
+const prompt = "List the files in the workspace, then read src/auth.ts and tell me if there are any security issues. Keep your response under 100 words.";
+
+console.log("\n[user]", prompt, "\n");
+
+const startedAt = Date.now();
+const counts = {};
+const toolCalls = [];
+const toolHandlerCalls = [];
+let toolsAvailableCount = null;
+
+// Wrap les handlers pour observer s'ils sont vraiment exécutés (vs juste appelés
+// par Claude mais bloqués par les permissions du SDK)
+const originalListHandler = novaListFiles.handler;
+const originalOpenHandler = novaOpenFile.handler;
+novaListFiles.handler = async (...args) => {
+  toolHandlerCalls.push({ name: "nova_listFiles", args: args[0] });
+  return originalListHandler(...args);
+};
+novaOpenFile.handler = async (...args) => {
+  toolHandlerCalls.push({ name: "nova_openFile", args: args[0] });
+  return originalOpenHandler(...args);
+};
+
+const q = query({
+  prompt,
+  options: {
+    model: "claude-sonnet-4-6",
+    tools: [],
+    settingSources: [],
+    mcpServers: { nova: novaServer },
+
+    // CHANGEMENT vs test3 — auto-approve nos tools Nova de confiance.
+    // Wildcard "mcp__nova__*" couvre tous les tools du serveur "nova".
+    allowedTools: ["mcp__nova__nova_listFiles", "mcp__nova__nova_openFile"],
+  },
+});
+
+for await (const msg of q) {
+  counts[msg.type] = (counts[msg.type] || 0) + 1;
+
+  switch (msg.type) {
+    case "system":
+      if (msg.subtype === "init") {
+        toolsAvailableCount = msg.tools?.length ?? null;
+        console.log(`[system:init] session=${msg.session_id?.slice(0, 8)}… model=${msg.model}`);
+        console.log(`[system:init] tools available: ${toolsAvailableCount}`);
+      }
+      break;
+
+    case "assistant": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+        } else if (block.type === "tool_use") {
+          console.log(`\n[assistant→tool_use] ${block.name}(${JSON.stringify(block.input)})`);
+          toolCalls.push({ name: block.name, input: block.input });
+        }
+      }
+      break;
+    }
+
+    case "user": {
+      const content = msg.message?.content ?? [];
+      for (const block of content) {
+        if (block.type === "tool_result") {
+          const text = Array.isArray(block.content)
+            ? block.content.map((c) => c.text).join("")
+            : block.content;
+          const isPermissionDenied = typeof text === "string" && text.includes("haven't granted");
+          const tag = isPermissionDenied ? "[tool_result:DENIED]" : "[tool_result]";
+          console.log(`\n${tag} ${text?.slice(0, 100) ?? "(empty)"}${text?.length > 100 ? "…" : ""}`);
+        }
+      }
+      break;
+    }
+
+    case "result": {
+      const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+      console.log(`\n\n─ Result: ${msg.subtype}`);
+      if (msg.subtype === "success") {
+        if (msg.usage) {
+          console.log(`─ Tokens: in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
+        }
+        if (msg.total_cost_usd != null) {
+          console.log(`─ Cost: $${msg.total_cost_usd.toFixed(4)} USD`);
+        }
+      } else {
+        console.log(`─ Error:`, msg);
+      }
+      console.log(`─ Elapsed: ${elapsed}s`);
+      console.log(`─ Tool calls (assistant intent) : ${toolCalls.length}`);
+      console.log(`─ Tool handlers (réellement exécutés) : ${toolHandlerCalls.length}`);
+      break;
+    }
+  }
+}
+
+const handlersRan = toolHandlerCalls.length >= 1;
+const allCallsResolved = toolHandlerCalls.length === toolCalls.length;
+
+console.log("\n─ Évaluation finale :");
+console.log(`    Tools dispo : ${toolsAvailableCount} ${toolsAvailableCount === 2 ? "✓" : "(attendu: 2)"}`);
+console.log(`    Tools appelés par Claude : ${toolCalls.length}`);
+console.log(`    Handlers exécutés (auto-approuvés) : ${toolHandlerCalls.length} ${handlersRan ? "✓" : "✗"}`);
+console.log(`    Toutes les requêtes résolues : ${allCallsResolved ? "✓" : "✗"}`);
+
+if (handlersRan && allCallsResolved) {
+  console.log("\n─ ✅ Test 4 PASS — config production-ready pour le sprint Chat UI.");
+  process.exit(0);
+} else {
+  console.log("\n─ ✗ Test 4 FAIL — auto-approval n'a pas fonctionné comme prévu.");
+  console.log("─ Investigation à faire : wildcard non supporté ? canUseTool nécessaire ?");
+  process.exit(1);
+}

--- a/spike/m2-chat-ui/.gitignore
+++ b/spike/m2-chat-ui/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+*.log
+public/lib/*.min.js
+public/lib/*.min.css

--- a/spike/m2-chat-ui/README.md
+++ b/spike/m2-chat-ui/README.md
@@ -1,0 +1,103 @@
+# M2 — Pure-browser chat UI demo
+
+**Statut :** prêt à tester
+**Date :** 2026-05-28
+
+Démo browser-only du chat UI Nova alimenté par `@anthropic-ai/claude-agent-sdk`. Valide l'UX (rendu markdown, syntax highlighting, copy buttons, tool cards) avant d'intégrer dans le Preview tab de Nova.
+
+## Lancer
+
+```bash
+cd spike/m2-chat-ui
+npm install                          # une seule fois — ~100 packages, 4 sec
+npm run start:1pass                  # lit la clé depuis 1Password puis démarre
+# ou
+export ANTHROPIC_API_KEY=sk-ant-...
+npm start
+```
+
+Puis ouvrir **http://127.0.0.1:5180/** dans Safari ou Firefox.
+
+## Ce que tu peux tester
+
+Trois prompts suggérés s'affichent au chargement :
+
+1. **« List the files in the workspace and tell me what this project does. »** → Claude appelle `nova_listFiles`, reçoit la liste, résume.
+2. **« Read src/auth.ts and identify any security issues. »** → Claude appelle `nova_openFile`, reçoit le code (qui contient un bypass admin volontaire), produit un audit.
+3. **« Get the diagnostics for src/auth.ts. »** → Claude appelle `nova_getDiagnostics`.
+
+Tu peux aussi taper tes propres prompts. Les **tools sont des mocks** — workspace fictif défini dans `chat-tool-mocks.mjs`. Quand on intégrera dans Nova, ces handlers feront un round-trip JSON-lines vers `main.js`.
+
+## Ce que la démo prouve
+
+| Capacité | Comment vérifier |
+|---|---|
+| **Streaming markdown** | La réponse de Claude apparaît progressivement, en HTML rendu (pas en raw text) |
+| **Syntax highlighting** | Les blocs de code (```ts, ```bash, etc.) sont colorés via highlight.js |
+| **Copy-to-clipboard** | Survole un bloc de code → bouton « Copy » apparaît, click → contenu copié |
+| **Tool call cards** | Chaque appel d'outil s'affiche dans une carte pliable jaune. Click pour voir input + result |
+| **Multi-turn session** | Le `session_id` est conservé entre messages — Claude se souvient de la conversation |
+| **Cost tracking** | Footer affiche le coût + tokens du dernier échange (devrait être ~$0.005-0.02) |
+| **Abort mid-stream** | Pendant que Claude répond, bouton « Stop » apparaît à droite. Click → query annulée |
+| **Auto-reconnect** | Si tu kill le server, l'UI affiche « Disconnected » et reconnecte quand tu relances |
+
+## Architecture du démo
+
+```
+[Safari/Firefox tab]
+  ↕ WS ws://127.0.0.1:5180/ws (JSON messages)
+[server.mjs (Node)]
+  ├── http.createServer (sert /public/*)
+  ├── ws.WebSocketServer (chat protocol)
+  └── @anthropic-ai/claude-agent-sdk
+      ├── query() loop → AsyncGenerator d'events SDKMessage
+      └── mcpServers: { nova: createSdkMcpServer(... mocks ...) }
+```
+
+## Protocole WebSocket (pour référence)
+
+**Client → Server :**
+```json
+{ "type": "user_message", "text": "..." }
+{ "type": "abort" }
+```
+
+**Server → Client :**
+```json
+{ "type": "session_started",   "sessionId": "...", "model": "claude-sonnet-4-6" }
+{ "type": "assistant_text",     "chunk": "..." }
+{ "type": "assistant_tool_use", "name": "mcp__nova__nova_openFile", "input": {...} }
+{ "type": "tool_result",        "name": "...", "text": "...", "isError": false }
+{ "type": "result",             "success": true, "cost": 0.0094, "tokens": {"input":4,"output":236} }
+{ "type": "error",              "message": "..." }
+```
+
+## Coût attendu par interaction
+
+- Prompts courts (1 réponse, 0-1 tool call) : **~$0.005-0.01**
+- Prompts complexes (multi-step, plusieurs tool calls) : **~$0.02-0.05**
+
+Avec ton modèle `claude-sonnet-4-6` + isolation (pas de built-in tools, pas de settings auto-loadés) + auto-approval des tools Nova. Voir `spike/m1-agent-sdk/SPIKE.md` pour les détails de calibrage.
+
+## Limitations connues du démo
+
+- **Pas de persistance des sessions au reload de la page** — chaque rechargement = nouvelle conversation. La persistance arrivera dans M3 (intégration Nova) via `~/.claude/projects/.../`.
+- **Pas de sélecteur de modèle dans l'UI** — Sonnet 4.6 hard-codé. Facile à exposer si on en a besoin.
+- **CDN pour marked + highlight.js** — pour la prod (Preview tab Nova), on vendor-isera. CDN pour la démo = setup rapide.
+- **Tools mockés** — bien sûr. Le but est de valider l'UX, pas les vraies opérations Nova.
+
+## Prochaines étapes
+
+Si l'UX te convient :
+- **M3 — Intégration Nova réelle** : promotion de ce code vers `claudecode-nova.novaextension/Scripts/`, branchement des wrappers in-process sur les vrais tools Nova MCP, exposition via Preview tab.
+
+Si l'UX te déçoit, on adapte avant d'intégrer.
+
+## Fichiers
+
+- `server.mjs` — backend HTTP + WS + SDK loop
+- `chat-tool-mocks.mjs` — 3 tools Nova mockés
+- `public/index.html` — layout
+- `public/chat.css` — dark theme
+- `public/chat.js` — WS client, render, tool cards, copy
+- `package.json`, `.gitignore`, `README.md`

--- a/spike/m2-chat-ui/chat-tool-mocks.mjs
+++ b/spike/m2-chat-ui/chat-tool-mocks.mjs
@@ -1,0 +1,133 @@
+// chat-tool-mocks.mjs — fake Nova tools for the M2 demo.
+//
+// These mock the round-trip that the real extension will do (ws-server.js
+// ↔ JSON lines ↔ Nova main.js ↔ editor). For the demo we just simulate
+// realistic latency and return canned content.
+//
+// When we promote this code into the real extension, each mock here gets
+// replaced by a JSON-line round-trip to Nova's main.js.
+
+import { tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+// Fake workspace fixture — simulates what Nova would expose
+const fakeWorkspace = {
+  "src/auth.ts": `import { hashPassword, verifyPassword } from "./crypto";
+import { db } from "./db";
+
+export async function login(user: string, pwd: string) {
+  // FIXME: hardcoded admin bypass — security issue, remove before prod
+  if (user === "admin") return { ok: true, role: "admin" };
+
+  const record = await db.users.findOne({ username: user });
+  if (!record) return { ok: false, reason: "no-such-user" };
+
+  const valid = await verifyPassword(pwd, record.passwordHash);
+  return valid ? { ok: true, role: record.role } : { ok: false, reason: "bad-password" };
+}
+
+export async function register(user: string, pwd: string) {
+  if (pwd.length < 8) throw new Error("Password too short");
+  const passwordHash = await hashPassword(pwd);
+  await db.users.insertOne({ username: user, passwordHash, role: "member" });
+}`,
+
+  "src/crypto.ts": `import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+export async function hashPassword(pwd: string): Promise<string> {
+  const salt = randomBytes(16).toString("hex");
+  const hash = scryptSync(pwd, salt, 64).toString("hex");
+  return \`\${salt}:\${hash}\`;
+}
+
+export async function verifyPassword(pwd: string, stored: string): Promise<boolean> {
+  const [salt, hash] = stored.split(":");
+  const test = scryptSync(pwd, salt, 64);
+  return timingSafeEqual(Buffer.from(hash, "hex"), test);
+}`,
+
+  "README.md": "# Demo workspace\n\nThis is a fake workspace used by the M2 chat UI demo to exercise the Nova tool wrappers without needing a real editor.",
+
+  "package.json": JSON.stringify({ name: "demo-workspace", version: "1.0.0" }, null, 2),
+};
+
+// Simulated diagnostics — what Nova's getDiagnostics would return
+const fakeDiagnostics = {
+  "src/auth.ts": [
+    {
+      severity: "warning",
+      line: 5,
+      message: "Hardcoded credential check should be removed",
+      source: "eslint-security",
+    },
+  ],
+  "src/crypto.ts": [],
+};
+
+// Helper — simulates network/IPC latency
+const simulate = (ms = 80) => new Promise((r) => setTimeout(r, ms));
+
+export const novaListFiles = tool(
+  "nova_listFiles",
+  "List all files in the current Nova workspace.",
+  {},
+  async () => {
+    await simulate();
+    return {
+      content: [{ type: "text", text: Object.keys(fakeWorkspace).sort().join("\n") }],
+    };
+  },
+);
+
+export const novaOpenFile = tool(
+  "nova_openFile",
+  "Read the contents of a file in the Nova workspace.",
+  {
+    path: z.string().describe("Path relative to the workspace root"),
+  },
+  async (args) => {
+    await simulate();
+    const content = fakeWorkspace[args.path];
+    if (content === undefined) {
+      return {
+        content: [{ type: "text", text: `Error: file not found: ${args.path}` }],
+        isError: true,
+      };
+    }
+    return { content: [{ type: "text", text: content }] };
+  },
+);
+
+export const novaGetDiagnostics = tool(
+  "nova_getDiagnostics",
+  "Get linter/compiler diagnostics for a file in the Nova workspace.",
+  {
+    path: z.string().describe("Path relative to the workspace root"),
+  },
+  async (args) => {
+    await simulate();
+    const diags = fakeDiagnostics[args.path];
+    if (diags === undefined) {
+      return {
+        content: [{ type: "text", text: `No file at path: ${args.path}` }],
+        isError: true,
+      };
+    }
+    if (diags.length === 0) {
+      return { content: [{ type: "text", text: "No diagnostics." }] };
+    }
+    const formatted = diags
+      .map((d) => `[${d.severity}] line ${d.line}: ${d.message} (${d.source})`)
+      .join("\n");
+    return { content: [{ type: "text", text: formatted }] };
+  },
+);
+
+export const allMockTools = [novaListFiles, novaOpenFile, novaGetDiagnostics];
+
+// List the tool names with the `mcp__<server>__` prefix the SDK applies
+export const allowedToolNames = [
+  "mcp__nova__nova_listFiles",
+  "mcp__nova__nova_openFile",
+  "mcp__nova__nova_getDiagnostics",
+];

--- a/spike/m2-chat-ui/package.json
+++ b/spike/m2-chat-ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "m2-chat-ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Milestone 1 — pure-browser chat UI demo. Validates the SDK + WebSocket + markdown rendering UX before integrating into the Nova extension.",
+  "scripts": {
+    "start": "node server.mjs",
+    "start:1pass": "ANTHROPIC_API_KEY=$(op read \"op://Private/Anthropic API Key/credential\") node server.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "ws": "^8.18.0",
+    "zod": "^4.0.0"
+  }
+}

--- a/spike/m2-chat-ui/public/chat.css
+++ b/spike/m2-chat-ui/public/chat.css
@@ -1,0 +1,414 @@
+/* chat.css — dark theme, system font stack, no framework. */
+
+:root {
+  --bg:           #1e1e22;
+  --bg-elevated:  #26262b;
+  --bg-input:     #2a2a30;
+  --border:       #3a3a42;
+  --text:         #e8e8ea;
+  --text-muted:   #9a9aa3;
+  --accent:       #7c9eff;
+  --accent-warm:  #ffb454;
+  --user-bg:      #2e3a52;
+  --assistant-bg: #1e1e22;
+  --tool-bg:      #252027;
+  --tool-border:  #4a3a52;
+  --error:        #ff7676;
+  --success:      #6cd07a;
+
+  --radius:       8px;
+  --gap:          12px;
+  --code-bg:      #15151a;
+  --font-mono:    ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans:    -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── topbar ─────────────────────────────────────────────────────── */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  flex-shrink: 0;
+}
+
+.topbar__brand {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.topbar__sub {
+  margin-left: 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.topbar__status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #555;
+}
+
+.dot--idle      { background: #555; }
+.dot--connected { background: var(--success); }
+.dot--thinking  { background: var(--accent); animation: pulse 1.2s infinite; }
+.dot--error     { background: var(--error); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+
+/* ── chat area ──────────────────────────────────────────────────── */
+
+.chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.chat__empty {
+  margin: auto;
+  text-align: left;
+  color: var(--text-muted);
+}
+
+.chat__empty-title {
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.chat__empty-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.suggestion {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.suggestion:hover {
+  border-color: var(--accent);
+  background: var(--bg-input);
+}
+
+.msg {
+  max-width: 880px;
+  width: 100%;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.msg__role {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.msg__body {
+  background: var(--assistant-bg);
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  word-wrap: break-word;
+}
+
+.msg--user .msg__body {
+  background: var(--user-bg);
+  border-color: #3a4a6a;
+}
+
+.msg--user {
+  align-self: flex-end;
+  max-width: 80%;
+}
+
+.msg__body p:first-child { margin-top: 0; }
+.msg__body p:last-child  { margin-bottom: 0; }
+
+.msg__body pre {
+  background: var(--code-bg);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 8px 0;
+  position: relative;
+}
+
+.msg__body code {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
+.msg__body :not(pre) > code {
+  background: var(--code-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12.5px;
+}
+
+.msg__body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  width: 100%;
+}
+
+.msg__body th, .msg__body td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+}
+
+.msg__body th {
+  background: var(--bg-elevated);
+}
+
+.msg__body blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 12px;
+  color: var(--text-muted);
+  margin: 8px 0;
+}
+
+/* ── code copy button ───────────────────────────────────────────── */
+
+.code-copy {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.msg__body pre:hover .code-copy { opacity: 1; }
+
+.code-copy:hover { color: var(--text); border-color: var(--accent); }
+.code-copy.copied { color: var(--success); border-color: var(--success); }
+
+/* ── tool call card ─────────────────────────────────────────────── */
+
+.tool {
+  background: var(--tool-bg);
+  border: 1px solid var(--tool-border);
+  border-radius: var(--radius);
+  padding: 0;
+  overflow: hidden;
+  max-width: 880px;
+  align-self: flex-start;
+}
+
+.tool__header {
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  background: var(--tool-bg);
+  user-select: none;
+}
+
+.tool__icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: var(--accent-warm);
+  flex-shrink: 0;
+}
+
+.tool__name {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--accent-warm);
+}
+
+.tool__summary {
+  color: var(--text-muted);
+  font-size: 12px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tool__caret {
+  color: var(--text-muted);
+  transition: transform 0.15s;
+}
+
+.tool.expanded .tool__caret { transform: rotate(90deg); }
+
+.tool__details {
+  display: none;
+  padding: 0 12px 12px;
+  border-top: 1px solid var(--tool-border);
+  margin-top: 4px;
+}
+
+.tool.expanded .tool__details { display: block; }
+
+.tool__section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 10px 0 4px;
+}
+
+.tool__pre {
+  background: var(--code-bg);
+  padding: 8px 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.tool.error .tool__icon { background: var(--error); }
+.tool.error .tool__name { color: var(--error); }
+
+/* ── composer ───────────────────────────────────────────────────── */
+
+.composer {
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: 10px 18px 14px;
+  flex-shrink: 0;
+}
+
+.composer__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-family: var(--font-mono);
+}
+
+.composer__row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+#input {
+  flex: 1;
+  resize: vertical;
+  min-height: 42px;
+  max-height: 200px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  padding: 10px 12px;
+}
+
+#input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.btn {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  font: inherit;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: var(--accent); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #15151a;
+  font-weight: 600;
+}
+
+.btn--primary:hover { background: #9bb5ff; }
+
+.btn--secondary {
+  background: var(--bg-input);
+  color: var(--error);
+  border-color: var(--error);
+}
+
+/* ── scrollbar ──────────────────────────────────────────────────── */
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #3a3a42; border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: #4a4a55; }
+
+/* ── error message ──────────────────────────────────────────────── */
+
+.error-msg {
+  color: var(--error);
+  font-size: 12px;
+  padding: 8px 12px;
+  background: rgba(255, 118, 118, 0.08);
+  border: 1px solid rgba(255, 118, 118, 0.3);
+  border-radius: var(--radius);
+  align-self: flex-start;
+  max-width: 880px;
+}

--- a/spike/m2-chat-ui/public/chat.js
+++ b/spike/m2-chat-ui/public/chat.js
@@ -1,0 +1,320 @@
+// chat.js — chat UI client: WebSocket + markdown render + tool cards + copy.
+//
+// Single-file vanilla JS. No bundler. Uses globals from CDN scripts :
+//   - marked (markdown parser)
+//   - hljs   (highlight.js)
+
+const $ = (id) => document.getElementById(id);
+
+const chatEl     = $("chat");
+const inputEl    = $("input");
+const sendBtn    = $("send");
+const abortBtn   = $("abort");
+const statusDot  = $("status-dot");
+const statusText = $("status-text");
+const emptyState = $("empty-state");
+const metaSess   = $("meta-session");
+const metaCost   = $("meta-cost");
+
+let ws = null;
+let inFlight = false;
+let currentAssistantBubble = null;
+let currentAssistantBuffer = "";
+let toolCardsByName = []; // queue of cards waiting for a matching tool_result
+
+// ── markdown render setup ─────────────────────────────────────────
+
+function setupMarked() {
+  if (typeof marked === "undefined") {
+    console.warn("marked not yet loaded — retrying");
+    return false;
+  }
+  marked.setOptions({
+    breaks: true,
+    gfm: true,
+  });
+  return true;
+}
+
+function renderMarkdown(text) {
+  if (typeof marked === "undefined") return escapeHtml(text);
+  return marked.parse(text);
+}
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function highlightCodeBlocks(rootEl) {
+  if (typeof hljs === "undefined") return;
+  rootEl.querySelectorAll("pre code").forEach((block) => {
+    if (block.dataset.highlighted) return;
+    hljs.highlightElement(block);
+    block.dataset.highlighted = "true";
+    addCopyButton(block.parentElement); // the <pre>
+  });
+}
+
+function addCopyButton(preEl) {
+  if (preEl.querySelector(".code-copy")) return;
+  const btn = document.createElement("button");
+  btn.className = "code-copy";
+  btn.textContent = "Copy";
+  btn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    const code = preEl.querySelector("code");
+    try {
+      await navigator.clipboard.writeText(code.innerText);
+      btn.textContent = "Copied!";
+      btn.classList.add("copied");
+      setTimeout(() => {
+        btn.textContent = "Copy";
+        btn.classList.remove("copied");
+      }, 1500);
+    } catch (err) {
+      btn.textContent = "Error";
+    }
+  });
+  preEl.appendChild(btn);
+}
+
+// ── DOM helpers for message bubbles ───────────────────────────────
+
+function hideEmptyState() {
+  if (emptyState) emptyState.style.display = "none";
+}
+
+function appendUserMessage(text) {
+  hideEmptyState();
+  const wrap = document.createElement("div");
+  wrap.className = "msg msg--user";
+  wrap.innerHTML = `
+    <div class="msg__role">You</div>
+    <div class="msg__body"></div>
+  `;
+  wrap.querySelector(".msg__body").textContent = text;
+  chatEl.appendChild(wrap);
+  scrollToBottom();
+}
+
+function ensureAssistantBubble() {
+  if (currentAssistantBubble) return currentAssistantBubble;
+  hideEmptyState();
+  const wrap = document.createElement("div");
+  wrap.className = "msg msg--assistant";
+  wrap.innerHTML = `
+    <div class="msg__role">Claude</div>
+    <div class="msg__body"></div>
+  `;
+  chatEl.appendChild(wrap);
+  currentAssistantBubble = wrap.querySelector(".msg__body");
+  currentAssistantBuffer = "";
+  return currentAssistantBubble;
+}
+
+function appendAssistantText(chunk) {
+  const body = ensureAssistantBubble();
+  currentAssistantBuffer += chunk;
+  body.innerHTML = renderMarkdown(currentAssistantBuffer);
+  highlightCodeBlocks(body);
+  scrollToBottom();
+}
+
+function appendToolCard(name, input) {
+  hideEmptyState();
+  // Close any open assistant bubble so the next assistant_text starts a new one
+  currentAssistantBubble = null;
+  currentAssistantBuffer = "";
+
+  const card = document.createElement("div");
+  card.className = "tool";
+  const summary = Object.keys(input).length
+    ? JSON.stringify(input)
+    : "(no args)";
+  card.innerHTML = `
+    <div class="tool__header" role="button">
+      <span class="tool__icon"></span>
+      <span class="tool__name">${escapeHtml(prettyToolName(name))}</span>
+      <span class="tool__summary">${escapeHtml(summary)}</span>
+      <span class="tool__caret">▶</span>
+    </div>
+    <div class="tool__details">
+      <div class="tool__section-label">Input</div>
+      <pre class="tool__pre">${escapeHtml(JSON.stringify(input, null, 2))}</pre>
+      <div class="tool__section-label tool__result-label" hidden>Result</div>
+      <pre class="tool__pre tool__result" hidden></pre>
+    </div>
+  `;
+  card.querySelector(".tool__header").addEventListener("click", () => {
+    card.classList.toggle("expanded");
+  });
+  chatEl.appendChild(card);
+  toolCardsByName.push({ name, card });
+  scrollToBottom();
+}
+
+function attachToolResult(name, text, isError) {
+  // Find the first card matching this name (FIFO matching)
+  const idx = toolCardsByName.findIndex((c) => c.name === name);
+  const target = idx >= 0 ? toolCardsByName.splice(idx, 1)[0].card : null;
+  if (!target) return;
+
+  if (isError) target.classList.add("error");
+
+  const label = target.querySelector(".tool__result-label");
+  const pre   = target.querySelector(".tool__result");
+  label.hidden = false;
+  pre.hidden = false;
+  pre.textContent = text;
+}
+
+function prettyToolName(name) {
+  // "mcp__nova__nova_openFile" → "nova_openFile"
+  return name.replace(/^mcp__[^_]+__/, "");
+}
+
+function appendErrorMessage(text) {
+  const el = document.createElement("div");
+  el.className = "error-msg";
+  el.textContent = "Error: " + text;
+  chatEl.appendChild(el);
+  scrollToBottom();
+}
+
+function scrollToBottom() {
+  chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+// ── WebSocket ─────────────────────────────────────────────────────
+
+function connect() {
+  const wsUrl = `ws://${location.host}/ws`;
+  ws = new WebSocket(wsUrl);
+  setStatus("idle", "Connecting…");
+
+  ws.addEventListener("open", () => {
+    setStatus("connected", "Ready");
+  });
+
+  ws.addEventListener("close", () => {
+    setStatus("error", "Disconnected — reconnecting…");
+    setTimeout(connect, 1500);
+  });
+
+  ws.addEventListener("error", () => {
+    setStatus("error", "WebSocket error");
+  });
+
+  ws.addEventListener("message", (event) => {
+    let msg;
+    try { msg = JSON.parse(event.data); }
+    catch { return; }
+    handleServerMessage(msg);
+  });
+}
+
+function handleServerMessage(msg) {
+  switch (msg.type) {
+    case "session_started":
+      metaSess.textContent = `session ${msg.sessionId.slice(0, 8)}… · model ${msg.model}`;
+      setStatus("thinking", "Claude is working…");
+      break;
+
+    case "assistant_text":
+      appendAssistantText(msg.chunk);
+      break;
+
+    case "assistant_tool_use":
+      appendToolCard(msg.name, msg.input);
+      break;
+
+    case "tool_result":
+      attachToolResult(msg.name, msg.text, msg.isError);
+      break;
+
+    case "result":
+      setStatus("connected", "Ready");
+      inFlight = false;
+      abortBtn.hidden = true;
+      sendBtn.disabled = false;
+      currentAssistantBubble = null;
+      currentAssistantBuffer = "";
+      if (msg.success && msg.cost != null) {
+        const tk = msg.tokens
+          ? ` · in ${msg.tokens.input} / out ${msg.tokens.output} tk`
+          : "";
+        metaCost.textContent = `last cost $${msg.cost.toFixed(4)}${tk}`;
+      } else if (!msg.success) {
+        appendErrorMessage(msg.error || "query failed");
+      }
+      break;
+
+    case "error":
+      appendErrorMessage(msg.message);
+      setStatus("connected", "Ready");
+      inFlight = false;
+      abortBtn.hidden = true;
+      sendBtn.disabled = false;
+      break;
+  }
+}
+
+function setStatus(kind, text) {
+  statusDot.className = "dot dot--" + kind;
+  statusText.textContent = text;
+}
+
+// ── send flow ─────────────────────────────────────────────────────
+
+function sendUserMessage() {
+  const text = inputEl.value.trim();
+  if (!text || inFlight || !ws || ws.readyState !== WebSocket.OPEN) return;
+  inFlight = true;
+  appendUserMessage(text);
+  ws.send(JSON.stringify({ type: "user_message", text }));
+  inputEl.value = "";
+  sendBtn.disabled = true;
+  abortBtn.hidden = false;
+  setStatus("thinking", "Sending…");
+}
+
+function abortQuery() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "abort" }));
+}
+
+// ── input wiring ──────────────────────────────────────────────────
+
+sendBtn.addEventListener("click", sendUserMessage);
+abortBtn.addEventListener("click", abortQuery);
+
+inputEl.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    sendUserMessage();
+  }
+});
+
+document.querySelectorAll(".suggestion").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    inputEl.value = btn.dataset.prompt;
+    sendUserMessage();
+  });
+});
+
+// ── boot ──────────────────────────────────────────────────────────
+
+window.addEventListener("load", () => {
+  // Wait for marked + hljs to be available
+  const tryStart = () => {
+    if (setupMarked() && typeof hljs !== "undefined") {
+      connect();
+    } else {
+      setTimeout(tryStart, 80);
+    }
+  };
+  tryStart();
+});

--- a/spike/m2-chat-ui/public/index.html
+++ b/spike/m2-chat-ui/public/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Claude Code · Nova chat (M2 demo)</title>
+  <link rel="stylesheet" href="chat.css" />
+  <!-- highlight.js for code blocks (atom-one-dark theme) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/styles/atom-one-dark.min.css" />
+  <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/highlight.min.js"></script>
+  <!-- marked for markdown rendering -->
+  <script defer src="https://cdn.jsdelivr.net/npm/marked@13.0.3/marked.min.js"></script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar__title">
+      <span class="topbar__brand">Claude Code · Nova</span>
+      <span class="topbar__sub">M2 chat UI demo</span>
+    </div>
+    <div class="topbar__status" id="status">
+      <span class="dot dot--idle" id="status-dot"></span>
+      <span id="status-text">Connecting…</span>
+    </div>
+  </header>
+
+  <main class="chat" id="chat">
+    <div class="chat__empty" id="empty-state">
+      <div class="chat__empty-title">Try something like :</div>
+      <ul class="chat__empty-list">
+        <li><button class="suggestion" data-prompt="List the files in the workspace and tell me what this project does.">List the files in the workspace and tell me what this project does.</button></li>
+        <li><button class="suggestion" data-prompt="Read src/auth.ts and identify any security issues.">Read src/auth.ts and identify any security issues.</button></li>
+        <li><button class="suggestion" data-prompt="Get the diagnostics for src/auth.ts.">Get the diagnostics for src/auth.ts.</button></li>
+      </ul>
+    </div>
+  </main>
+
+  <footer class="composer">
+    <div class="composer__meta" id="meta">
+      <span id="meta-session"></span>
+      <span id="meta-cost"></span>
+    </div>
+    <div class="composer__row">
+      <textarea
+        id="input"
+        placeholder="Ask Claude…  (Enter to send, Shift+Enter for newline)"
+        rows="2"
+        autofocus
+      ></textarea>
+      <button id="send" class="btn btn--primary" title="Send (Enter)">Send</button>
+      <button id="abort" class="btn btn--secondary" title="Abort current query" hidden>Stop</button>
+    </div>
+  </footer>
+
+  <script type="module" src="chat.js"></script>
+</body>
+</html>

--- a/spike/m2-chat-ui/server.mjs
+++ b/spike/m2-chat-ui/server.mjs
@@ -1,0 +1,247 @@
+// server.mjs — HTTP + WebSocket server for the M2 chat UI demo.
+//
+// Endpoints :
+//   GET  /              → public/index.html
+//   GET  /chat.js       → public/chat.js
+//   GET  /chat.css      → public/chat.css
+//   GET  /lib/<file>    → public/lib/<file>   (marked, highlight.js)
+//   WS   /ws            → chat WebSocket
+//
+// Chat WebSocket protocol :
+//
+//   Client → Server :
+//     { type: "user_message", text: string }
+//     { type: "abort" }
+//
+//   Server → Client :
+//     { type: "session_started", sessionId, model }
+//     { type: "assistant_text",  chunk }
+//     { type: "assistant_tool_use", name, input }
+//     { type: "tool_result", name, text, isError }
+//     { type: "result", success, cost, tokens }
+//     { type: "error", message }
+
+import { createServer } from "http";
+import { readFile } from "fs/promises";
+import { join, dirname, extname } from "path";
+import { fileURLToPath } from "url";
+import { WebSocketServer } from "ws";
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+
+import { allMockTools, allowedToolNames } from "./chat-tool-mocks.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = join(__dirname, "public");
+const PORT = Number(process.env.PORT) || 5180;
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ERROR: ANTHROPIC_API_KEY not set.");
+  console.error("Run with :  npm run start:1pass");
+  console.error("       or :  export ANTHROPIC_API_KEY=sk-ant-... && npm start");
+  process.exit(1);
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".woff2": "font/woff2",
+};
+
+// --- HTTP server (static files) -------------------------------------------
+
+const httpServer = createServer(async (req, res) => {
+  try {
+    let path = req.url.split("?")[0];
+    if (path === "/") path = "/index.html";
+
+    // Prevent directory traversal
+    if (path.includes("..")) {
+      res.writeHead(403);
+      return res.end("Forbidden");
+    }
+
+    const filePath = join(PUBLIC_DIR, path);
+    const data = await readFile(filePath);
+    const mime = MIME[extname(filePath)] || "application/octet-stream";
+    res.writeHead(200, { "content-type": mime, "cache-control": "no-cache" });
+    res.end(data);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      res.writeHead(404);
+      res.end("Not Found");
+    } else {
+      console.error("HTTP error :", err);
+      res.writeHead(500);
+      res.end("Internal Server Error");
+    }
+  }
+});
+
+// --- WebSocket server -----------------------------------------------------
+
+const wss = new WebSocketServer({ server: httpServer, path: "/ws" });
+
+const novaServer = createSdkMcpServer({
+  name: "nova",
+  version: "0.0.0",
+  tools: allMockTools,
+});
+
+wss.on("connection", (socket, req) => {
+  console.log(`[ws] client connected from ${req.socket.remoteAddress}`);
+
+  let currentAbortController = null;
+  let currentSessionId = null;
+
+  const send = (msg) => {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(JSON.stringify(msg));
+    }
+  };
+
+  socket.on("message", async (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString("utf8"));
+    } catch {
+      send({ type: "error", message: "invalid JSON" });
+      return;
+    }
+
+    if (msg.type === "abort") {
+      if (currentAbortController) {
+        currentAbortController.abort();
+        console.log("[ws] aborted current query");
+      }
+      return;
+    }
+
+    if (msg.type !== "user_message" || typeof msg.text !== "string") {
+      send({ type: "error", message: "unsupported message type" });
+      return;
+    }
+
+    if (currentAbortController) {
+      send({ type: "error", message: "previous query still running" });
+      return;
+    }
+
+    currentAbortController = new AbortController();
+    console.log(`[ws] user_message: ${msg.text.slice(0, 60)}…`);
+
+    try {
+      const q = query({
+        prompt: msg.text,
+        options: {
+          model: "claude-sonnet-4-6",
+          tools: [],
+          settingSources: [],
+          mcpServers: { nova: novaServer },
+          allowedTools: allowedToolNames,
+          abortController: currentAbortController,
+          // Resume previous session if we have one (multi-turn)
+          ...(currentSessionId ? { resume: currentSessionId } : {}),
+        },
+      });
+
+      for await (const event of q) {
+        switch (event.type) {
+          case "system":
+            if (event.subtype === "init") {
+              if (!currentSessionId) currentSessionId = event.session_id;
+              send({
+                type: "session_started",
+                sessionId: event.session_id,
+                model: event.model ?? "unknown",
+              });
+            }
+            break;
+
+          case "assistant": {
+            const content = event.message?.content ?? [];
+            for (const block of content) {
+              if (block.type === "text") {
+                send({ type: "assistant_text", chunk: block.text });
+              } else if (block.type === "tool_use") {
+                send({
+                  type: "assistant_tool_use",
+                  name: block.name,
+                  input: block.input,
+                });
+              }
+            }
+            break;
+          }
+
+          case "user": {
+            // tool_result blocks come back inside user messages
+            const content = event.message?.content ?? [];
+            for (const block of content) {
+              if (block.type === "tool_result") {
+                const text = Array.isArray(block.content)
+                  ? block.content.map((c) => c.text ?? "").join("")
+                  : (block.content ?? "");
+                send({
+                  type: "tool_result",
+                  name: block.name ?? "unknown",
+                  text,
+                  isError: !!block.is_error,
+                });
+              }
+            }
+            break;
+          }
+
+          case "result":
+            send({
+              type: "result",
+              success: event.subtype === "success",
+              cost: event.total_cost_usd ?? null,
+              tokens: event.usage
+                ? { input: event.usage.input_tokens, output: event.usage.output_tokens }
+                : null,
+              ...(event.subtype !== "success" ? { error: event.error ?? String(event) } : {}),
+            });
+            break;
+
+          // Other event types (stream_event, hooks, etc.) — silently consumed
+          default:
+            break;
+        }
+      }
+    } catch (err) {
+      if (err.name === "AbortError") {
+        send({ type: "error", message: "query aborted" });
+      } else {
+        console.error("[ws] query error :", err);
+        send({ type: "error", message: err.message || String(err) });
+      }
+    } finally {
+      currentAbortController = null;
+    }
+  });
+
+  socket.on("close", () => {
+    console.log("[ws] client disconnected");
+    if (currentAbortController) currentAbortController.abort();
+  });
+
+  socket.on("error", (err) => {
+    console.error("[ws] socket error :", err.message);
+  });
+});
+
+httpServer.listen(PORT, "127.0.0.1", () => {
+  console.log("─".repeat(60));
+  console.log(` M2 chat UI demo running`);
+  console.log(`─ Open : http://127.0.0.1:${PORT}/`);
+  console.log(`─ WS   : ws://127.0.0.1:${PORT}/ws`);
+  console.log(`─ Tools: ${allowedToolNames.join(", ")}`);
+  console.log("─ Hit Ctrl+C to stop.");
+  console.log("─".repeat(60));
+});


### PR DESCRIPTION
## Summary

- Adds an **opt-in chat UI** alongside the existing CLI bridge — runs in Safari/Firefox or directly inside Nova's Preview tab, powered by `@anthropic-ai/claude-agent-sdk` with **12 Nova editor tools wrapped in-process**. Mode A (external `claude` CLI via MCP) and Mode B (hosted chat) coexist on different ports.
- **Cost-tuned defaults** : Sonnet 4.6, `tools: []`, `settingSources: []`, wildcard `allowedTools` → typical interaction ~$0.01–0.02 vs ~$0.67 with stock SDK defaults (calibration documented in `spike/m1-agent-sdk/SPIKE.md`).
- Also bundles the **Claude Code CLI version-check sidebar + auto-update flow** (Marc's pre-existing 0.6.0 work) and archives the **M0/M1/M2 spike directories** with SPIKE.md reports for future reference.

## Architecture highlights

- `Scripts/chat-session.mjs` — HTTP+WS server, lazy-loaded by `ws-server.js` only when `claudecode.chat.enabled=true`
- `Scripts/chat-tool-wrappers.mjs` — 12 in-process `tool()` definitions wrapping `openFile`, `openDiff`, `getCurrentSelection`, etc.
- `Scripts/ws-server.js` — shared `pendingRequests` map dispatched by `kind: \"mcp\" | \"chat\"`, single Nova round-trip path
- `Scripts/chat-ui/` — static HTML/CSS/JS (no build step ; marked + highlight.js via CDN for now)
- 1Password CLI integration : `claudecode.chat.apiKey1PassRef = \"op://Private/Anthropic API Key/credential\"` runs `op read` at activation

## Test plan

- [x] **M2 spike browser standalone** — Safari, chat renders, tool calls work
- [x] **End-to-end in extension** — `ws-server.js` spawned with `CC_CHAT_*` env vars, chat module loads, HTTP+WS reachable on port 5180
- [x] **Real Nova tool calls** — `nova_openFile` actually opens the file in Nova's editor (via the existing JSON-line round-trip)
- [x] **Nova Preview tab** — chat UI loads inside Nova's WebKit Preview with Project Settings → Aperçu → Custom URL configured
- [ ] Vendor CDN libs (marked + highlight.js) locally for offline resilience
- [ ] Live status display in the new \"Chat UI\" sidebar section (currently placeholder text only)
- [ ] esbuild bundling for distribution (deferred ; node_modules ships ~50 MB unbundled for now)
- [ ] Bump version 0.6.0 → 0.7.0 at release time

## Files changed

38 files / +7094 / -40

- Chat backend : `chat-session.mjs`, `chat-tool-wrappers.mjs`, `chat-ui/*`, `package.json` (deps : sdk + ws + zod)
- `ws-server.js` : env-driven chat opt-in, shared `pendingRequests` dispatch
- `main.js` + `Scripts/main.js` : async `startBridge`, `resolveChatApiKey`, `runOpRead`, `openChatHandler`, new server-message handlers
- `extension.json` : 5 new config keys, `claudecode.openChat` command, new sidebar section
- Spikes : `spike/m0-node-pty/`, `spike/m1-agent-sdk/`, `spike/m2-chat-ui/` (node_modules + package-lock gitignored)
- Pre-existing 0.6.0 work : `Scripts/update-check.js`, `version-tree-provider.js`, `docs/specs/claude-code-update-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)