### PR TITLE
feat(chat): store API key in macOS Keychain (preferred source)

### DIFF
--- a/claudecode-nova.novaextension/CHANGELOG.md
+++ b/claudecode-nova.novaextension/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.1 — 2026-05-28
+
+### Added
+- **macOS Keychain as the preferred Anthropic API key source for chat (Mode B).**
+  Two new commands : `Claude Code Bridge: Set Claude Chat API Key (Keychain)`
+  prompts for the key via a secure-input notification and stores it via
+  `nova.credentials.setPassword("ca.okapi.claudecode-nova", "anthropic-api-key", …)` ;
+  `Claude Code Bridge: Clear Claude Chat API Key (Keychain)` removes it.
+- **`resolveChatApiKey()` priority order revisited** : Keychain first
+  (persistent, no session expiry), then 1Password CLI (only if a reference
+  is configured), then the plain-text `claudecode.chat.apiKey` config as
+  last resort. Eliminates the silent-failure case where `op read` fails
+  because the 1Password CLI session expired (~30 min) and the bridge
+  silently spawned without `CC_CHAT_ENABLED`.
+
+### Changed
+- Settings descriptions clarified : 1Password ref now warns about session
+  expiry and points to the Keychain command as the recommended source.
+
 ## 0.6.0 — 2026-05-28
 
 ### Added

--- a/claudecode-nova.novaextension/Scripts/main.js
+++ b/claudecode-nova.novaextension/Scripts/main.js
@@ -87,6 +87,8 @@ exports.activate = function() {
       nova.commands.register("claudecode.sidebarRefresh", sidebarRefreshHandler),
       nova.commands.register("claudecode.checkForUpdates", function() { checkForUpdates(false); }),
       nova.commands.register("claudecode.openChat", openChatHandler),
+      nova.commands.register("claudecode.setChatApiKey", setChatApiKeyHandler),
+      nova.commands.register("claudecode.clearChatApiKey", clearChatApiKeyHandler),
     );
     console.log("Claude Code Bridge: commands registered");
   } catch (err) {
@@ -168,23 +170,102 @@ function resolveNodePath() {
 // Chat (Mode B) — opt-in chat UI helpers
 // ---------------------------------------------------------------------------
 
-// Resolve the Anthropic API key for chat mode. Tries 1Password CLI first
-// (via `op read <ref>`), falls back to the direct config value. Returns
-// the key string, or empty string if no source is configured / op fails.
-async function resolveChatApiKey() {
-  const opRef  = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
-  const direct = (nova.config.get("claudecode.chat.apiKey") || "").trim();
+// macOS Keychain service/account for the chat API key. Native, persistent,
+// no session-expiry issue (unlike 1Password CLI). Preferred source.
+const CHAT_KEYCHAIN_SERVICE = "ca.okapi.claudecode-nova";
+const CHAT_KEYCHAIN_ACCOUNT = "anthropic-api-key";
 
+// Resolve the Anthropic API key for chat mode. Priority order :
+//   1. macOS Keychain (native, persistent)
+//   2. 1Password CLI (op read — requires active `op signin` session)
+//   3. Plain-text config value (last-resort fallback)
+// Returns the key, or empty string if no source yields one.
+async function resolveChatApiKey() {
+  // 1) Keychain — preferred (set via the "Set Claude Chat API Key" command)
+  const kc = await readChatKeyFromKeychain();
+  if (kc) return kc;
+
+  // 2) 1Password CLI — only if a reference is configured
+  const opRef = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
   if (opRef) {
     try {
       const key = await runOpRead(opRef);
       if (key) return key;
     } catch (err) {
-      console.warn("Claude Code Bridge: op read failed (" + err.message + ") — falling back to direct key");
+      console.warn("Claude Code Bridge: op read failed (" + err.message + ")");
     }
   }
 
-  return direct;
+  // 3) Direct config — last-resort plain-text fallback
+  return (nova.config.get("claudecode.chat.apiKey") || "").trim();
+}
+
+// Read the API key from the macOS Keychain. Empty string on miss/error
+// (no entry, denied access, etc.) — caller falls through to next source.
+async function readChatKeyFromKeychain() {
+  try {
+    const key = await nova.credentials.getPassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT);
+    return (key || "").trim();
+  } catch (_) {
+    return "";
+  }
+}
+
+// "Set Claude Chat API Key" command — secure-input notification, stores
+// the key in macOS Keychain. The user must restart the bridge after for
+// the new key to take effect.
+async function setChatApiKeyHandler() {
+  const req = new NotificationRequest("claudecode.setChatApiKey");
+  req.title = "Set Claude Chat API Key";
+  req.body  = "Paste your Anthropic API key (starts with `sk-ant-…`). It will be stored in macOS Keychain — restart the bridge for it to take effect.";
+  req.type  = "secure-input";
+  req.textInputPlaceholder = "sk-ant-...";
+  req.actions = ["Save", "Cancel"];
+
+  let reply;
+  try {
+    reply = await nova.notifications.add(req);
+  } catch (err) {
+    console.warn("Claude Code Bridge: setChatApiKey notification cancelled — " + err.message);
+    return;
+  }
+
+  if (reply.actionIdx !== 0) return; // Cancel
+
+  const key = (reply.textInputValue || "").trim();
+  if (!key) {
+    showNotification("Empty key", "No API key entered — nothing stored.");
+    return;
+  }
+  if (!key.startsWith("sk-ant-")) {
+    showNotification(
+      "Suspicious format",
+      "The key does not start with `sk-ant-`. Stored anyway — verify it's an Anthropic API key."
+    );
+  }
+
+  try {
+    await nova.credentials.setPassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT, key);
+    showNotification(
+      "Saved to Keychain",
+      "API key stored. Use `Claude Code Bridge: Restart Claude Code Bridge` for it to take effect."
+    );
+  } catch (err) {
+    showNotification("Save failed", "Could not store the key in Keychain: " + err.message);
+  }
+}
+
+// "Clear Claude Chat API Key" command — removes the Keychain entry.
+async function clearChatApiKeyHandler() {
+  try {
+    await nova.credentials.removePassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT);
+    showNotification(
+      "Cleared",
+      "API key removed from Keychain. The bridge will fall back to 1Password or direct config on next restart."
+    );
+  } catch (err) {
+    showNotification("Clear failed", err.message);
+  }
 }
 
 // Run `op read <ref>` and capture stdout. Resolves with the trimmed output

--- a/claudecode-nova.novaextension/Scripts/package.json
+++ b/claudecode-nova.novaextension/Scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudecode-nova-scripts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "commonjs",
   "description": "Node subprocess scripts for the Claude Code Nova extension. ws-server.js is CommonJS (uses node built-ins only). chat-session.mjs is ES Modules (uses SDK).",

--- a/claudecode-nova.novaextension/extension.json
+++ b/claudecode-nova.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Claude Code Bridge",
   "organization": "okapi-ca",
   "description": "Integrates Claude Code CLI with Nova via the WebSocket MCP protocol, providing context sharing, diff viewing, and selection tracking.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "categories": ["commands", "sidebars"],
   "license": "MIT",
   "repository": "https://github.com/okapi-ca/claudecode-nova",
@@ -60,6 +60,14 @@
       {
         "title": "Open Claude Chat in Browser",
         "command": "claudecode.openChat"
+      },
+      {
+        "title": "Set Claude Chat API Key (Keychain)",
+        "command": "claudecode.setChatApiKey"
+      },
+      {
+        "title": "Clear Claude Chat API Key (Keychain)",
+        "command": "claudecode.clearChatApiKey"
       },
       {
         "title": "Check for Claude Code Updates",
@@ -235,17 +243,17 @@
     },
     {
       "key": "claudecode.chat.apiKey1PassRef",
-      "title": "Anthropic API Key — 1Password reference",
+      "title": "Anthropic API Key — 1Password reference (optional)",
       "type": "string",
       "default": "",
-      "description": "1Password CLI reference like `op://Private/Anthropic API Key/credential`. Read at extension activation via `op read`. Leave empty if using the env var fallback or to disable chat auth."
+      "description": "1Password CLI reference like `op://Private/Anthropic API Key/credential`. Requires an active `op signin` session ; expires after ~30 min, then chat init fails silently until re-signin. The macOS Keychain (set via 'Set Claude Chat API Key' command) is the recommended source — persistent, no session expiry."
     },
     {
       "key": "claudecode.chat.apiKey",
-      "title": "Anthropic API Key — direct (fallback if 1Password not configured)",
+      "title": "Anthropic API Key — direct (last-resort fallback)",
       "type": "string",
       "default": "",
-      "description": "Direct API key — used only if the 1Password reference above is empty. Prefer the 1Password reference for security."
+      "description": "Plain-text API key — used only if both the Keychain AND 1Password reference are empty. Stored in Nova settings (not encrypted at rest). Prefer the Keychain via 'Set Claude Chat API Key' command."
     },
     {
       "key": "claudecode.chat.model",

--- a/claudecode-nova.novaextension/main.js
+++ b/claudecode-nova.novaextension/main.js
@@ -87,6 +87,8 @@ exports.activate = function() {
       nova.commands.register("claudecode.sidebarRefresh", sidebarRefreshHandler),
       nova.commands.register("claudecode.checkForUpdates", function() { checkForUpdates(false); }),
       nova.commands.register("claudecode.openChat", openChatHandler),
+      nova.commands.register("claudecode.setChatApiKey", setChatApiKeyHandler),
+      nova.commands.register("claudecode.clearChatApiKey", clearChatApiKeyHandler),
     );
     console.log("Claude Code Bridge: commands registered");
   } catch (err) {
@@ -168,23 +170,102 @@ function resolveNodePath() {
 // Chat (Mode B) — opt-in chat UI helpers
 // ---------------------------------------------------------------------------
 
-// Resolve the Anthropic API key for chat mode. Tries 1Password CLI first
-// (via `op read <ref>`), falls back to the direct config value. Returns
-// the key string, or empty string if no source is configured / op fails.
-async function resolveChatApiKey() {
-  const opRef  = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
-  const direct = (nova.config.get("claudecode.chat.apiKey") || "").trim();
+// macOS Keychain service/account for the chat API key. Native, persistent,
+// no session-expiry issue (unlike 1Password CLI). Preferred source.
+const CHAT_KEYCHAIN_SERVICE = "ca.okapi.claudecode-nova";
+const CHAT_KEYCHAIN_ACCOUNT = "anthropic-api-key";
 
+// Resolve the Anthropic API key for chat mode. Priority order :
+//   1. macOS Keychain (native, persistent)
+//   2. 1Password CLI (op read — requires active `op signin` session)
+//   3. Plain-text config value (last-resort fallback)
+// Returns the key, or empty string if no source yields one.
+async function resolveChatApiKey() {
+  // 1) Keychain — preferred (set via the "Set Claude Chat API Key" command)
+  const kc = await readChatKeyFromKeychain();
+  if (kc) return kc;
+
+  // 2) 1Password CLI — only if a reference is configured
+  const opRef = (nova.config.get("claudecode.chat.apiKey1PassRef") || "").trim();
   if (opRef) {
     try {
       const key = await runOpRead(opRef);
       if (key) return key;
     } catch (err) {
-      console.warn("Claude Code Bridge: op read failed (" + err.message + ") — falling back to direct key");
+      console.warn("Claude Code Bridge: op read failed (" + err.message + ")");
     }
   }
 
-  return direct;
+  // 3) Direct config — last-resort plain-text fallback
+  return (nova.config.get("claudecode.chat.apiKey") || "").trim();
+}
+
+// Read the API key from the macOS Keychain. Empty string on miss/error
+// (no entry, denied access, etc.) — caller falls through to next source.
+async function readChatKeyFromKeychain() {
+  try {
+    const key = await nova.credentials.getPassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT);
+    return (key || "").trim();
+  } catch (_) {
+    return "";
+  }
+}
+
+// "Set Claude Chat API Key" command — secure-input notification, stores
+// the key in macOS Keychain. The user must restart the bridge after for
+// the new key to take effect.
+async function setChatApiKeyHandler() {
+  const req = new NotificationRequest("claudecode.setChatApiKey");
+  req.title = "Set Claude Chat API Key";
+  req.body  = "Paste your Anthropic API key (starts with `sk-ant-…`). It will be stored in macOS Keychain — restart the bridge for it to take effect.";
+  req.type  = "secure-input";
+  req.textInputPlaceholder = "sk-ant-...";
+  req.actions = ["Save", "Cancel"];
+
+  let reply;
+  try {
+    reply = await nova.notifications.add(req);
+  } catch (err) {
+    console.warn("Claude Code Bridge: setChatApiKey notification cancelled — " + err.message);
+    return;
+  }
+
+  if (reply.actionIdx !== 0) return; // Cancel
+
+  const key = (reply.textInputValue || "").trim();
+  if (!key) {
+    showNotification("Empty key", "No API key entered — nothing stored.");
+    return;
+  }
+  if (!key.startsWith("sk-ant-")) {
+    showNotification(
+      "Suspicious format",
+      "The key does not start with `sk-ant-`. Stored anyway — verify it's an Anthropic API key."
+    );
+  }
+
+  try {
+    await nova.credentials.setPassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT, key);
+    showNotification(
+      "Saved to Keychain",
+      "API key stored. Use `Claude Code Bridge: Restart Claude Code Bridge` for it to take effect."
+    );
+  } catch (err) {
+    showNotification("Save failed", "Could not store the key in Keychain: " + err.message);
+  }
+}
+
+// "Clear Claude Chat API Key" command — removes the Keychain entry.
+async function clearChatApiKeyHandler() {
+  try {
+    await nova.credentials.removePassword(CHAT_KEYCHAIN_SERVICE, CHAT_KEYCHAIN_ACCOUNT);
+    showNotification(
+      "Cleared",
+      "API key removed from Keychain. The bridge will fall back to 1Password or direct config on next restart."
+    );
+  } catch (err) {
+    showNotification("Clear failed", err.message);
+  }
 }
 
 // Run `op read <ref>` and capture stdout. Resolves with the trimmed output


### PR DESCRIPTION
## Summary

- Adds **macOS Keychain** as the preferred source for the Anthropic API key via `nova.credentials.{get,set,remove}Password`, fixing the silent-failure case in 0.6.0 where `op read` fails after the 1Password CLI session expires (~30 min) and the bridge respawns without `CC_CHAT_ENABLED`.
- Two new commands : **Set Claude Chat API Key (Keychain)** (secure-input notification, stored in Keychain) and **Clear Claude Chat API Key (Keychain)**.
- New priority order in `resolveChatApiKey()` : **Keychain → 1Password CLI → direct config**.

## Why

In 0.6.0 we shipped chat with 1Password CLI as the primary key source. In practice, `op` sessions expire — and when they do, `op read` returns a non-zero exit from a non-TTY subprocess (no biometric prompt possible), `resolveChatApiKey()` catches and silently falls through. The bridge then spawns `ws-server.js` without `CC_CHAT_ENABLED`, the chat endpoint isn't there, and the only signal is `connection refused` on port 5180.

Keychain bypasses this : it's native, persistent across Nova restarts, doesn't expire, and prompts for permission only once.

## Files changed (5)

- `claudecode-nova.novaextension/extension.json` : 2 new commands ; clarified descriptions for 1Password / direct-config keys ; version bump to 0.6.1
- `claudecode-nova.novaextension/Scripts/package.json` : version bump
- `claudecode-nova.novaextension/main.js` + `Scripts/main.js` (mirrored) : `readChatKeyFromKeychain`, `setChatApiKeyHandler`, `clearChatApiKeyHandler`, updated `resolveChatApiKey` priority order
- `claudecode-nova.novaextension/CHANGELOG.md` : 0.6.1 section

## Test plan

- [x] Syntax check both `main.js` files (diff between root + Scripts/ remains only the require paths)
- [ ] Run `Claude Code Bridge: Set Claude Chat API Key (Keychain)` → paste key → restart bridge → chat starts
- [ ] Verify Keychain entry via macOS Keychain Access app (service `ca.okapi.claudecode-nova`, account `anthropic-api-key`)
- [ ] Verify `Clear Claude Chat API Key (Keychain)` removes the entry
- [ ] Verify fallback order : Keychain set → use Keychain. Keychain cleared + 1Password ref configured + session active → use 1Password. Both empty → use direct config. All empty → notification "Chat key missing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)